### PR TITLE
Add 'reverse' weed to keep only selected split k-mers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ska"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
     "John Lees <jlees@ebi.ac.uk>",
     "Simon Harris <simon.harris@gatesfoundation.org>",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -228,6 +228,10 @@ pub enum Commands {
         /// A FASTA file containing sequences to remove
         weed_file: Option<String>,
 
+        /// Remove k-mers not in the weed_file
+        #[arg(long, default_value_t = false)]
+        reverse: bool,
+
         /// Minimum fraction of samples a k-mer has to appear in
         #[arg(short, long, value_parser = zero_to_one, default_value_t = 0.0)]
         min_freq: f64,

--- a/src/generic_modes.rs
+++ b/src/generic_modes.rs
@@ -114,6 +114,7 @@ pub fn delete<IntT: for<'a> UInt<'a>>(
 pub fn weed<IntT: for<'a> UInt<'a>>(
     ska_array: &mut MergeSkaArray<IntT>,
     weed_file: &Option<String>,
+    reverse: bool,
     min_freq: f64,
     filter: &FilterType,
     out_file: &str,
@@ -126,8 +127,12 @@ pub fn weed<IntT: for<'a> UInt<'a>>(
         );
         let ska_weed = RefSka::new(ska_array.kmer_len(), weed_fasta, ska_array.rc());
 
-        log::info!("Removing weed k-mers");
-        ska_array.weed(&ska_weed);
+        if !reverse {
+            log::info!("Removing weed k-mers");
+        } else {
+            log::info!("Keeping only weed k-mers");
+        }
+        ska_array.weed(&ska_weed, reverse);
     }
 
     let filter_threshold = f64::floor(ska_array.nsamples() as f64 * min_freq) as usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,14 +498,29 @@ pub fn main() {
         Commands::Weed {
             skf_file,
             weed_file,
+            reverse,
             min_freq,
             filter,
         } => {
             log::info!("Loading skf file");
             if let Ok(mut ska_array) = MergeSkaArray::<u64>::load(skf_file) {
-                weed(&mut ska_array, weed_file, *min_freq, filter, skf_file);
+                weed(
+                    &mut ska_array,
+                    weed_file,
+                    *reverse,
+                    *min_freq,
+                    filter,
+                    skf_file,
+                );
             } else if let Ok(mut ska_array) = MergeSkaArray::<u128>::load(skf_file) {
-                weed(&mut ska_array, weed_file, *min_freq, filter, skf_file);
+                weed(
+                    &mut ska_array,
+                    weed_file,
+                    *reverse,
+                    *min_freq,
+                    filter,
+                    skf_file,
+                );
             } else {
                 panic!("Could not read input file: {skf_file}");
             }

--- a/tests/align.rs
+++ b/tests/align.rs
@@ -6,7 +6,7 @@ use crate::common::*;
 use hashbrown::HashSet;
 
 #[cfg(test)]
-use pretty_assertions::{assert_eq};
+use pretty_assertions::assert_eq;
 
 // NB: to view output, uncomment the current_dir lines
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,7 @@ use predicates::prelude::*;
 use hashbrown::HashSet;
 
 #[cfg(test)]
-use pretty_assertions::{assert_eq};
+use pretty_assertions::assert_eq;
 
 // Creates correct path for input/output files
 static FILE_IN: &'static str = "tests/test_files_in";

--- a/tests/fasta_input.rs
+++ b/tests/fasta_input.rs
@@ -6,7 +6,7 @@ pub mod common;
 use crate::common::{var_hash, TestDir, TestSetup};
 
 #[cfg(test)]
-use pretty_assertions::{assert_eq};
+use pretty_assertions::assert_eq;
 
 #[test]
 fn align_n() {

--- a/tests/fastq_input.rs
+++ b/tests/fastq_input.rs
@@ -3,7 +3,7 @@ use snapbox::cmd::{cargo_bin, Command};
 use hashbrown::HashSet;
 
 #[cfg(test)]
-use pretty_assertions::{assert_eq};
+use pretty_assertions::assert_eq;
 
 pub mod common;
 use crate::common::*;

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -1,7 +1,7 @@
 use snapbox::cmd::{cargo_bin, Command};
 
 #[cfg(test)]
-use pretty_assertions::{assert_eq};
+use pretty_assertions::assert_eq;
 
 pub mod common;
 use crate::common::*;

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -1,5 +1,8 @@
 use snapbox::cmd::{cargo_bin, Command};
 
+#[cfg(test)]
+use pretty_assertions::{assert_eq};
+
 pub mod common;
 use crate::common::*;
 

--- a/tests/skf_ops.rs
+++ b/tests/skf_ops.rs
@@ -1,7 +1,7 @@
 use snapbox::cmd::{cargo_bin, Command};
 
 #[cfg(test)]
-use pretty_assertions::{assert_eq};
+use pretty_assertions::assert_eq;
 
 pub mod common;
 use crate::common::{TestDir, TestSetup};
@@ -201,6 +201,31 @@ fn weed() {
         .arg("--full-info")
         .assert()
         .stdout_matches_path(sandbox.file_string("weed_nk.stdout", TestDir::Correct));
+
+    // Keep rather than weed
+    Command::new("cp")
+        .current_dir(sandbox.get_wd())
+        .arg(sandbox.file_string("merge.skf", TestDir::Input))
+        .arg("merge.skf")
+        .assert()
+        .success();
+
+    Command::new(cargo_bin("ska"))
+        .current_dir(sandbox.get_wd())
+        .arg("weed")
+        .arg("merge.skf")
+        .arg(sandbox.file_string("weed.fa", TestDir::Input))
+        .arg("--reverse")
+        .arg("-v")
+        .assert()
+        .success();
+
+    Command::new(cargo_bin("ska"))
+        .current_dir(sandbox.get_wd())
+        .arg("align")
+        .arg("merge.skf")
+        .assert()
+        .stdout_eq_path(sandbox.file_string("weed_align_reverse.stdout", TestDir::Correct));
 
     // With longer k-mers
     Command::new(cargo_bin("ska"))

--- a/tests/test_results_correct/weed_align_reverse.stdout
+++ b/tests/test_results_correct/weed_align_reverse.stdout
@@ -1,0 +1,4 @@
+>test_1
+A
+>test_2
+T


### PR DESCRIPTION
Can be useful for e.g. keeping only the core genome