### PR TITLE
Fix filtering option name in documentation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@
 //!
 //! With an `.skf` file from `ska build`, constant sites, and no missing variants:
 //! ```bash
-//! ska align --min-freq 1 --filter NoFilter -o seqs seqs.skf
+//! ska align --min-freq 1 --filter no-filter -o seqs seqs.skf
 //! ```
 //!
 //! Another example: directly from FASTA files, with default `build` and `align` settings,


### PR DESCRIPTION
Fix name of the no filter option passed to `--filter` in the documentation.