### PR TITLE
Filter tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ska"
-version = "0.3.4"
+version = "0.3.5"
 authors = [
     "John Lees <jlees@ebi.ac.uk>",
     "Simon Harris <simon.harris@gatesfoundation.org>",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,8 @@ use super::QualFilter;
 pub const DEFAULT_KMER: usize = 17;
 /// Default single strand (which is equivalent to !rc)
 pub const DEFAULT_STRAND: bool = false;
+/// Default behaviour when min-freq counting ambig sites
+pub const DEFAULT_AMBIGMISSING: bool = false;
 /// Default repeat masking behaviour
 pub const DEFAULT_REPEATMASK: bool = false;
 /// Default ambiguous masking behaviour
@@ -174,6 +176,10 @@ pub enum Commands {
         #[arg(short, long, value_parser = zero_to_one, default_value_t = 0.9)]
         min_freq: f64,
 
+        /// With min_freq, only count non-ambiguous sites
+        #[arg(long, default_value_t = DEFAULT_AMBIGMISSING)]
+        filter_ambig_as_missing: bool,
+
         /// Filter for constant middle base sites
         #[arg(long, value_enum, default_value_t = FilterType::NoConst)]
         filter: FilterType,
@@ -285,6 +291,10 @@ pub enum Commands {
         /// Minimum fraction of samples a k-mer has to appear in
         #[arg(short, long, value_parser = zero_to_one, default_value_t = 0.0)]
         min_freq: f64,
+
+        /// With min_freq, only count non-ambiguous sites
+        #[arg(long, default_value_t = DEFAULT_AMBIGMISSING)]
+        filter_ambig_as_missing: bool,
 
         /// Filter for constant middle base sites
         #[arg(long, value_enum, default_value_t = FilterType::NoFilter)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,11 +16,11 @@ pub const DEFAULT_AMBIGMASK: bool = false;
 /// Default gap ignoring behaviour (at constant sites)
 pub const DEFAULT_CONSTGAPS: bool = false;
 /// Default minimum k-mer count for FASTQ files
-pub const DEFAULT_MINCOUNT: u16 = 10;
+pub const DEFAULT_MINCOUNT: u16 = 5;
 /// Default minimum base quality (PHRED score) for FASTQ files
 pub const DEFAULT_MINQUAL: u8 = 20;
 /// Default quality filtering criteria
-pub const DEFAULT_QUALFILTER: QualFilter = QualFilter::Middle;
+pub const DEFAULT_QUALFILTER: QualFilter = QualFilter::Strict;
 
 #[doc(hidden)]
 fn valid_kmer(s: &str) -> Result<usize, String> {
@@ -153,7 +153,7 @@ pub enum Commands {
         min_qual: u8,
 
         /// Quality filtering criteria (with reads)
-        #[arg(long, value_enum, default_value_t = QualFilter::Strict)]
+        #[arg(long, value_enum, default_value_t = DEFAULT_QUALFILTER)]
         qual_filter: QualFilter,
 
         /// Number of CPU threads

--- a/src/generic_modes.rs
+++ b/src/generic_modes.rs
@@ -28,7 +28,14 @@ pub fn align<IntT: for<'a> UInt<'a>>(
     log::debug!("{ska_array}");
 
     // Apply filters
-    apply_filters(ska_array, min_freq, filter_ambig_as_missing, filter, mask_ambig, ignore_const_gaps);
+    apply_filters(
+        ska_array,
+        min_freq,
+        filter_ambig_as_missing,
+        filter,
+        mask_ambig,
+        ignore_const_gaps,
+    );
 
     // Write out to file/stdout
     log::info!("Writing alignment");

--- a/src/generic_modes.rs
+++ b/src/generic_modes.rs
@@ -118,7 +118,7 @@ pub fn apply_filters<IntT: for<'a> UInt<'a>>(
 ) -> i32 {
     let update_kmers = false;
     let filter_threshold = f64::ceil(ska_array.nsamples() as f64 * min_freq) as usize;
-    log::info!("Applying filters: threshold={filter_threshold} constant_site_filter={filter} ambig_mask={ambig_mask} no_gap_only_sites={ignore_const_gaps}");
+    log::info!("Applying filters: threshold={filter_threshold} constant_site_filter={filter} filter_ambig_as_missing={filter_ambig_as_missing} ambig_mask={ambig_mask} no_gap_only_sites={ignore_const_gaps}");
     ska_array.filter(
         filter_threshold,
         filter_ambig_as_missing,
@@ -257,7 +257,7 @@ pub fn weed<IntT: for<'a> UInt<'a>>(
 
     let filter_threshold = f64::floor(ska_array.nsamples() as f64 * min_freq) as usize;
     if filter_threshold > 0 || *filter != FilterType::NoFilter || ambig_mask || ignore_const_gaps {
-        log::info!("Applying filters: threshold={filter_threshold} constant_site_filter={filter} ambig_mask={ambig_mask} no_gap_only_sites={ignore_const_gaps}");
+        log::info!("Applying filters: threshold={filter_threshold} constant_site_filter={filter} filter_ambig_as_missing={filter_ambig_as_missing} ambig_mask={ambig_mask} no_gap_only_sites={ignore_const_gaps}");
         let update_kmers = true;
         ska_array.filter(
             filter_threshold,

--- a/src/generic_modes.rs
+++ b/src/generic_modes.rs
@@ -22,12 +22,13 @@ pub fn align<IntT: for<'a> UInt<'a>>(
     mask_ambig: bool,
     ignore_const_gaps: bool,
     min_freq: f64,
+    filter_ambig_as_missing: bool,
 ) {
     // In debug mode (cannot be set from CLI, give details)
     log::debug!("{ska_array}");
 
     // Apply filters
-    apply_filters(ska_array, min_freq, filter, mask_ambig, ignore_const_gaps);
+    apply_filters(ska_array, min_freq, filter_ambig_as_missing, filter, mask_ambig, ignore_const_gaps);
 
     // Write out to file/stdout
     log::info!("Writing alignment");
@@ -103,6 +104,7 @@ pub fn merge<IntT: for<'a> UInt<'a>>(
 pub fn apply_filters<IntT: for<'a> UInt<'a>>(
     ska_array: &mut MergeSkaArray<IntT>,
     min_freq: f64,
+    filter_ambig_as_missing: bool,
     filter: &FilterType,
     ambig_mask: bool,
     ignore_const_gaps: bool,
@@ -112,6 +114,7 @@ pub fn apply_filters<IntT: for<'a> UInt<'a>>(
     log::info!("Applying filters: threshold={filter_threshold} constant_site_filter={filter} ambig_mask={ambig_mask} no_gap_only_sites={ignore_const_gaps}");
     ska_array.filter(
         filter_threshold,
+        filter_ambig_as_missing,
         filter,
         ambig_mask,
         ignore_const_gaps,
@@ -134,9 +137,11 @@ pub fn distance<IntT: for<'a> UInt<'a>>(
 
     let mask_ambig = false;
     let ignore_const_gaps = false;
+    let filter_ambig_as_missing = false;
     let constant = apply_filters(
         ska_array,
         min_freq,
+        filter_ambig_as_missing,
         &FilterType::NoConst,
         mask_ambig,
         ignore_const_gaps,
@@ -146,6 +151,7 @@ pub fn distance<IntT: for<'a> UInt<'a>>(
             apply_filters(
                 ska_array,
                 min_freq,
+                filter_ambig_as_missing,
                 &FilterType::NoAmbigOrConst,
                 mask_ambig,
                 ignore_const_gaps,
@@ -154,6 +160,7 @@ pub fn distance<IntT: for<'a> UInt<'a>>(
             apply_filters(
                 ska_array,
                 min_freq,
+                filter_ambig_as_missing,
                 &FilterType::NoFilter,
                 mask_ambig,
                 ignore_const_gaps,
@@ -211,6 +218,7 @@ pub fn weed<IntT: for<'a> UInt<'a>>(
     weed_file: &Option<String>,
     reverse: bool,
     min_freq: f64,
+    filter_ambig_as_missing: bool,
     filter: &FilterType,
     ambig_mask: bool,
     ignore_const_gaps: bool,
@@ -246,6 +254,7 @@ pub fn weed<IntT: for<'a> UInt<'a>>(
         let update_kmers = true;
         ska_array.filter(
             filter_threshold,
+            filter_ambig_as_missing,
             filter,
             ambig_mask,
             ignore_const_gaps,

--- a/src/io_utils.rs
+++ b/src/io_utils.rs
@@ -59,7 +59,7 @@ pub fn load_array<IntT: for<'a> UInt<'a>>(
 ) -> Result<MergeSkaArray<IntT>, Box<dyn Error>> {
     // Obtain a merged ska array
     if input.len() == 1 {
-        log::info!("Single file as input, trying to load as skf");
+        log::info!("Single file as input, trying to load as skf {}-bits", IntT::n_bits());
         MergeSkaArray::load(input[0].as_str())
     } else {
         log::info!("Multiple files as input, running ska build with default settings");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,11 +368,12 @@
 //!
 //! // Apply filters
 //! let min_count = 2;
+//! let filter_ambig_as_missing = false;
 //! let update_kmers = false;
 //! let filter = FilterType::NoConst;
 //! let ignore_const_gaps = false;
 //! let ambig_mask = false;
-//! ska_array.filter(min_count, &filter, ambig_mask, ignore_const_gaps, update_kmers);
+//! ska_array.filter(min_count, filter_ambig_as_missing, &filter, ambig_mask, ignore_const_gaps, update_kmers);
 //!
 //! // Write out to stdout
 //! let mut out_stream = set_ostream(&None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -514,6 +514,7 @@ pub fn main() {
             input,
             output,
             min_freq,
+            filter_ambig_as_missing,
             filter,
             ambig_mask,
             no_gap_only_sites,
@@ -530,6 +531,7 @@ pub fn main() {
                     *ambig_mask,
                     *no_gap_only_sites,
                     *min_freq,
+                    *filter_ambig_as_missing,
                 );
             } else if let Ok(mut ska_array) = load_array::<u128>(input, *threads) {
                 // In debug mode (cannot be set from CLI, give details)
@@ -541,6 +543,7 @@ pub fn main() {
                     *ambig_mask,
                     *no_gap_only_sites,
                     *min_freq,
+                    *filter_ambig_as_missing,
                 );
             } else {
                 panic!("Could not read input file(s): {input:?}");
@@ -658,6 +661,7 @@ pub fn main() {
             output,
             reverse,
             min_freq,
+            filter_ambig_as_missing,
             ambig_mask,
             no_gap_only_sites,
             filter,
@@ -669,6 +673,7 @@ pub fn main() {
                     weed_file,
                     *reverse,
                     *min_freq,
+                    *filter_ambig_as_missing,
                     filter,
                     *ambig_mask,
                     *no_gap_only_sites,
@@ -684,6 +689,7 @@ pub fn main() {
                     weed_file,
                     *reverse,
                     *min_freq,
+                    *filter_ambig_as_missing,
                     filter,
                     *ambig_mask,
                     *no_gap_only_sites,

--- a/src/merge_ska_array.rs
+++ b/src/merge_ska_array.rs
@@ -245,6 +245,7 @@ where
     pub fn filter(
         &mut self,
         min_count: usize,
+        filter_ambig_as_missing: bool,
         filter: &FilterType,
         mask_ambig: bool,
         ignore_const_gaps: bool,

--- a/src/merge_ska_array.rs
+++ b/src/merge_ska_array.rs
@@ -54,11 +54,12 @@ use crate::cli::FilterType;
 ///
 /// // Remove constant sites and save
 /// let min_count = 1;                          // no filtering by minor allele frequency
+/// let filter_ambig_as_missing = false;        // allow ambiguous bases when counting allele frequency
 /// let filter = FilterType::NoAmbigOrConst;    // remove sites with no minor allele
 /// let mask_ambiguous = false;                 // leave ambiguous sites as IUPAC codes
 /// let ignore_const_gaps = false;              // keep sites with only '-' as variants
 /// let update_counts = true;                   // keep counts updated, as saving
-/// ska_array.filter(min_count, &filter, mask_ambiguous, ignore_const_gaps, update_counts);
+/// ska_array.filter(min_count, filter_ambig_as_missing, &filter, mask_ambiguous, ignore_const_gaps, update_counts);
 /// ska_array.save(&"no_const_sites.skf");
 ///
 /// // Create an iterators

--- a/tests/align.rs
+++ b/tests/align.rs
@@ -183,6 +183,7 @@ fn filters() {
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
         .arg("--filter")
         .arg("no-ambig")
+        .arg("--filter-ambig-as-missing")
         .arg("-v")
         .output()
         .unwrap()


### PR DESCRIPTION
Changes the default min-count to 5, which works better with a default of strict

Adds the `--filter_ambig_as_missing` option to `align` and `weed`, which alters the min count threshold

Closes #62 