### PR TITLE
Fix double file prefix; update VCF parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ska"
-version = "0.3.5"
+version = "0.3.6"
 authors = [
     "John Lees <jlees@ebi.ac.uk>",
     "Simon Harris <simon.harris@gatesfoundation.org>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,30 +29,30 @@ categories = ["command-line-utilities", "science"]
 
 [dependencies]
 # i/o
-needletail = { version = "0.4.1", features = ["compression"] }
-serde = { version = "1.0.147", features = ["derive"] }
-ciborium = "0.2.0"
-noodles-vcf = "0.22.0"
-snap = "1.1.0"
+needletail = { version = "0.5.1", features = ["compression"] }
+serde = { version = "1.0", features = ["derive"] }
+ciborium = "0.2"
+noodles-vcf = "0.49"
+snap = "1.1"
 # logging
-log = "0.4.17"
-simple_logger = { version = "4.0.0", features = ["stderr"] }
-indicatif = {version = "0.17.2", features = ["rayon"]}
+log = "0.4"
+simple_logger = { version = "4", features = ["stderr"] }
+indicatif = { version = "0.17", features = ["rayon"]}
 # cli
-clap = { version = "4.0.27", features = ["derive"] }
-regex = "1.7.0"
+clap = { version = "4.5", features = ["derive"] }
+regex = "1.10"
 # parallelisation
-rayon = "1.5.3"
+rayon = "1.8"
 num_cpus = "1.0"
 # data structures
-hashbrown = "0.12"
-ahash = "0.8.2"
-ndarray = { version = "0.15.6", features = ["serde", "rayon"] }
-num-traits = "0.2.15"
+hashbrown = "0.14"
+ahash = ">=0.8.7"
+ndarray = { version = "0.15", features = ["serde", "rayon"] }
+num-traits = "0.2"
 # coverage model
-libm = "0.2.7"
-argmin = { version = "0.8.1", features = ["slog-logger"] }
-argmin-math = "0.3.0"
+libm = "0.2"
+argmin = { version = "0.9", features = ["slog-logger"] }
+argmin-math = "0.3"
 
 [dev-dependencies]
 # testing

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -150,7 +150,7 @@ pub enum Commands {
         #[arg(long, default_value_t = DEFAULT_MINCOUNT)]
         min_count: u16,
 
-        /// Minimum k-mer count (with reads)
+        /// Minimum k-mer quality (with reads)
         #[arg(long, default_value_t = DEFAULT_MINQUAL)]
         min_qual: u8,
 

--- a/src/generic_modes.rs
+++ b/src/generic_modes.rs
@@ -98,9 +98,14 @@ pub fn merge<IntT: for<'a> UInt<'a>>(
     }
 
     log::info!("Converting and saving merged alignment");
+    let outfile = if output.ends_with(".skf") {
+        output.to_string()
+    } else {
+        format!("{output}.skf")
+    };
     let merged_array = MergeSkaArray::new(&merged_dict);
     merged_array
-        .save(format!("{output}.skf").as_str())
+        .save(&outfile)
         .expect("Failed to save output file");
 }
 

--- a/src/generic_modes.rs
+++ b/src/generic_modes.rs
@@ -98,15 +98,7 @@ pub fn merge<IntT: for<'a> UInt<'a>>(
     }
 
     log::info!("Converting and saving merged alignment");
-    let outfile = if output.ends_with(".skf") {
-        output.to_string()
-    } else {
-        format!("{output}.skf")
-    };
-    let merged_array = MergeSkaArray::new(&merged_dict);
-    merged_array
-        .save(&outfile)
-        .expect("Failed to save output file");
+    save_skf(&merged_dict, output);
 }
 
 /// Apply a constant/ambigbuous filter [`FilterType`] and a minimum frequency
@@ -282,9 +274,16 @@ pub fn weed<IntT: for<'a> UInt<'a>>(
 
 /// Covnvert a dictionary representation to an array and save to file
 pub fn save_skf<IntT: for<'a> UInt<'a>>(ska_dict: &MergeSkaDict<IntT>, out_file: &str) {
+    // Conditionally add suffix
+    let outfile_suffix = if out_file.ends_with(".skf") {
+        out_file.to_string()
+    } else {
+        format!("{out_file}.skf")
+    };
+
     log::info!("Converting to array representation and saving");
     let ska_array = MergeSkaArray::new(ska_dict);
     ska_array
-        .save(out_file)
+        .save(&outfile_suffix)
         .expect("Failed to save output file");
 }

--- a/src/io_utils.rs
+++ b/src/io_utils.rs
@@ -59,7 +59,10 @@ pub fn load_array<IntT: for<'a> UInt<'a>>(
 ) -> Result<MergeSkaArray<IntT>, Box<dyn Error>> {
     // Obtain a merged ska array
     if input.len() == 1 {
-        log::info!("Single file as input, trying to load as skf {}-bits", IntT::n_bits());
+        log::info!(
+            "Single file as input, trying to load as skf {}-bits",
+            IntT::n_bits()
+        );
         MergeSkaArray::load(input[0].as_str())
     } else {
         log::info!("Multiple files as input, running ska build with default settings");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,23 +497,19 @@ pub fn main() {
 
             // Build, merge
             let rc = !*single_strand;
-            let outfile = if output.ends_with(".skf") {
-                output.clone()
-            } else {
-                format!("{output}.skf")
-            };
+
             if *k <= 31 {
                 log::info!("k={}: using 64-bit representation", *k);
                 let merged_dict = build_and_merge::<u64>(&input_files, *k, rc, &quality, *threads);
 
                 // Save
-                save_skf(&merged_dict, &outfile);
+                save_skf(&merged_dict, &output);
             } else {
                 log::info!("k={}: using 128-bit representation", *k);
                 let merged_dict = build_and_merge::<u128>(&input_files, *k, rc, &quality, *threads);
 
                 // Save
-                save_skf(&merged_dict, &outfile);
+                save_skf(&merged_dict, &output);
             }
         }
         Commands::Align {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,18 +497,23 @@ pub fn main() {
 
             // Build, merge
             let rc = !*single_strand;
+            let outfile = if output.ends_with(".skf") {
+                output.clone()
+            } else {
+                format!("{output}.skf")
+            };
             if *k <= 31 {
                 log::info!("k={}: using 64-bit representation", *k);
                 let merged_dict = build_and_merge::<u64>(&input_files, *k, rc, &quality, *threads);
 
                 // Save
-                save_skf(&merged_dict, format!("{output}.skf").as_str());
+                save_skf(&merged_dict, &outfile);
             } else {
                 log::info!("k={}: using 128-bit representation", *k);
                 let merged_dict = build_and_merge::<u128>(&input_files, *k, rc, &quality, *threads);
 
                 // Save
-                save_skf(&merged_dict, format!("{output}.skf").as_str());
+                save_skf(&merged_dict, &outfile);
             }
         }
         Commands::Align {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,13 +503,13 @@ pub fn main() {
                 let merged_dict = build_and_merge::<u64>(&input_files, *k, rc, &quality, *threads);
 
                 // Save
-                save_skf(&merged_dict, &output);
+                save_skf(&merged_dict, output);
             } else {
                 log::info!("k={}: using 128-bit representation", *k);
                 let merged_dict = build_and_merge::<u128>(&input_files, *k, rc, &quality, *threads);
 
                 // Save
-                save_skf(&merged_dict, &output);
+                save_skf(&merged_dict, output);
             }
         }
         Commands::Align {

--- a/src/merge_ska_array.rs
+++ b/src/merge_ska_array.rs
@@ -680,7 +680,10 @@ mod tests {
 
         // Check if variants are updated correctly
         // Assuming `variants` should now contain only the non-empty rows
-        assert_eq!(merge_ska_array.variants, array![[b'A', b'G', b'Y'], [b'T', b'-', b'Y']]);
+        assert_eq!(
+            merge_ska_array.variants,
+            array![[b'A', b'G', b'Y'], [b'T', b'-', b'Y']]
+        );
 
         // Check if split_kmers are updated correctly
         assert_eq!(merge_ska_array.split_kmers, vec![1, 2]); // Expected kmers

--- a/tests/fasta_input.rs
+++ b/tests/fasta_input.rs
@@ -19,7 +19,7 @@ fn align_n() {
         .arg(sandbox.file_string("N_test_1.fa", TestDir::Input))
         .arg(sandbox.file_string("N_test_2.fa", TestDir::Input))
         .arg("-o")
-        .arg("N_test")
+        .arg("N_test.skf") // test no .skf.skf extension
         .assert()
         .success();
 

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -113,7 +113,7 @@ fn map_u128() {
         .arg("-f")
         .arg("vcf")
         .assert()
-        .stdout_eq_path(sandbox.file_string("map_vcf_k41.stdout", TestDir::Correct));
+        .stdout_matches_path(sandbox.file_string("map_vcf_k41.stdout", TestDir::Correct));
 }
 
 #[test]
@@ -143,7 +143,7 @@ fn map_vcf() {
         .arg("-f")
         .arg("vcf")
         .assert()
-        .stdout_eq_path(sandbox.file_string("map_vcf.stdout", TestDir::Correct));
+        .stdout_matches_path(sandbox.file_string("map_vcf.stdout", TestDir::Correct));
 
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
@@ -153,7 +153,7 @@ fn map_vcf() {
         .arg("-f")
         .arg("vcf")
         .assert()
-        .stdout_eq_path(sandbox.file_string("map_vcf_two_chrom.stdout", TestDir::Correct));
+        .stdout_matches_path(sandbox.file_string("map_vcf_two_chrom.stdout", TestDir::Correct));
 
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
@@ -164,7 +164,7 @@ fn map_vcf() {
         .arg("-f")
         .arg("vcf")
         .assert()
-        .stdout_eq_path(sandbox.file_string("map_vcf_indels.stdout", TestDir::Correct));
+        .stdout_matches_path(sandbox.file_string("map_vcf_indels.stdout", TestDir::Correct));
 }
 
 #[test]
@@ -232,7 +232,7 @@ fn map_rev_comp() {
         .arg("-f")
         .arg("vcf")
         .assert()
-        .stdout_eq_path(sandbox.file_string("map_vcf_ss.stdout", TestDir::Correct));
+        .stdout_matches_path(sandbox.file_string("map_vcf_ss.stdout", TestDir::Correct));
 }
 
 // Tests the --repeat-mask option
@@ -259,7 +259,7 @@ fn repeat_mask() {
         .arg("--repeat-mask")
         .args(&["--format", "vcf"])
         .assert()
-        .stdout_eq_path(sandbox.file_string("map_vcf_k9.masked.stdout", TestDir::Correct));
+        .stdout_matches_path(sandbox.file_string("map_vcf_k9.masked.stdout", TestDir::Correct));
 
     // Two identical chromosomes. All bases masked
     Command::new(cargo_bin("ska"))
@@ -291,5 +291,5 @@ fn repeat_mask() {
         .arg("--repeat-mask")
         .args(&["--format", "vcf"])
         .assert()
-        .stdout_eq_path(sandbox.file_string("map_vcf_two_chrom.masked.stdout", TestDir::Correct));
+        .stdout_matches_path(sandbox.file_string("map_vcf_two_chrom.masked.stdout", TestDir::Correct));
 }

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -291,5 +291,7 @@ fn repeat_mask() {
         .arg("--repeat-mask")
         .args(&["--format", "vcf"])
         .assert()
-        .stdout_matches_path(sandbox.file_string("map_vcf_two_chrom.masked.stdout", TestDir::Correct));
+        .stdout_matches_path(
+            sandbox.file_string("map_vcf_two_chrom.masked.stdout", TestDir::Correct),
+        );
 }

--- a/tests/test_results_correct/map_vcf.stdout
+++ b/tests/test_results_correct/map_vcf.stdout
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.3
+##fileformat=VCFv[..]
 ##contig=<ID=fake_ref>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test_1	test_2
 fake_ref	1	.	A	.	.	.	.	GT	.	.

--- a/tests/test_results_correct/map_vcf_indels.stdout
+++ b/tests/test_results_correct/map_vcf_indels.stdout
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.3
+##fileformat=VCFv[..]
 ##contig=<ID=fake_ref>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test_1	indel_test
 fake_ref	1	.	A	.	.	.	.	GT	.	.

--- a/tests/test_results_correct/map_vcf_k41.stdout
+++ b/tests/test_results_correct/map_vcf_k41.stdout
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.3
+##fileformat=VCFv[..]
 ##contig=<ID=fake_ref>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test_1	test_2
 fake_ref	1	.	A	.	.	.	.	GT	.	.

--- a/tests/test_results_correct/map_vcf_k9.masked.stdout
+++ b/tests/test_results_correct/map_vcf_k9.masked.stdout
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.3
+##fileformat=VCFv[..]
 ##contig=<ID=fake_ref>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test_1	test_2
 fake_ref	1	.	A	.	.	.	.	GT	.	.

--- a/tests/test_results_correct/map_vcf_ss.stdout
+++ b/tests/test_results_correct/map_vcf_ss.stdout
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.3
+##fileformat=VCFv[..]
 ##contig=<ID=fake_ref>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test_1	test_2_rc
 fake_ref	1	.	A	.	.	.	.	GT	.	.

--- a/tests/test_results_correct/map_vcf_two_chrom.masked.stdout
+++ b/tests/test_results_correct/map_vcf_two_chrom.masked.stdout
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.3
+##fileformat=VCFv[..]
 ##contig=<ID=fake_ref_chrom1>
 ##contig=<ID=fake_ref_chrom2>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test_1	test_2

--- a/tests/test_results_correct/map_vcf_two_chrom.stdout
+++ b/tests/test_results_correct/map_vcf_two_chrom.stdout
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.3
+##fileformat=VCFv[..]
 ##contig=<ID=fake_ref_chrom1>
 ##contig=<ID=fake_ref_chrom2>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	test_1	test_2


### PR DESCRIPTION
Updated the dependencies, including noodles which required some code changes. VCF header is more careful with chromosome names removing whitespace.

Also prevents .skf.skf file outputs

Closes #64 
Closes #65 