### PR TITLE
Covbuildmerge

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -167,8 +167,8 @@ pub enum Commands {
         single_strand: bool,
 
         /// Minimum k-mer count (with reads)
-        #[arg(long, default_value_t = DEFAULT_MINCOUNT)]
-        min_count: u16,
+        #[arg(long)]
+        min_count: Option<u16>,
 
         /// Minimum k-mer quality (with reads)
         #[arg(long, default_value_t = DEFAULT_MINQUAL)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 //! Command line interface, built using [`crate::clap` with `Derive`](https://docs.rs/clap/latest/clap/_derive/_tutorial/index.html)
 use std::fmt;
 
-use clap::{ArgGroup, Error, Parser, Subcommand, ValueEnum};
+use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
 
 use super::QualFilter;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,6 +84,22 @@ pub fn check_threads(threads: usize) {
     }
 }
 
+#[doc(hidden)]
+fn valid_kmer_min(s: &str) -> Result<u16, String> {
+    if s.eq("auto") {
+        Ok(0)
+    } else {
+        let k: u16 = s
+            .parse()
+            .map_err(|_| format!("`{s}` isn't a valid minimum kmer count"))?;
+        if k.ge(&5) {
+            Ok(k)
+        } else {
+            Err("minimum kmer count must be >= 5".to_string())
+        }
+    }
+}
+
 /// Possible output file types
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum FileType {
@@ -116,6 +132,11 @@ impl fmt::Display for FilterType {
             Self::NoAmbigOrConst => write!(f, "No constant sites or ambiguous bases"),
         }
     }
+}
+
+pub enum KmerMin {
+    Auto,
+    Value(u16),
 }
 
 /// Options that apply to all subcommands
@@ -168,7 +189,7 @@ pub enum Commands {
 
         /// Minimum k-mer count (with reads)
         #[arg(long)]
-        min_count: Option<u16>,
+        min_count: Option<String>,
 
         /// Minimum k-mer quality (with reads)
         #[arg(long, default_value_t = DEFAULT_MINQUAL)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,22 +84,6 @@ pub fn check_threads(threads: usize) {
     }
 }
 
-#[doc(hidden)]
-fn valid_kmer_min(s: &str) -> Result<u16, String> {
-    if s.eq("auto") {
-        Ok(0)
-    } else {
-        let k: u16 = s
-            .parse()
-            .map_err(|_| format!("`{s}` isn't a valid minimum kmer count"))?;
-        if k.ge(&5) {
-            Ok(k)
-        } else {
-            Err("minimum kmer count must be >= 5".to_string())
-        }
-    }
-}
-
 /// Possible output file types
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum FileType {

--- a/src/coverage.rs
+++ b/src/coverage.rs
@@ -392,7 +392,7 @@ mod tests {
         };
 
         let cutoff = test_obj.fit_histogram();
-        assert_eq!(cutoff.is_ok(), true);
+        assert!(cutoff.is_ok());
         assert_eq!(cutoff.unwrap(), 9);
 
         // The other template

--- a/src/io_utils.rs
+++ b/src/io_utils.rs
@@ -14,11 +14,13 @@ use super::QualOpts;
 use crate::merge_ska_array::MergeSkaArray;
 use crate::merge_ska_dict::{build_and_merge, InputFastx};
 use crate::ska_dict::bit_encoding::UInt;
+use crate::CoverageHistogram;
 
 use crate::cli::{
     DEFAULT_KMER, DEFAULT_MINCOUNT, DEFAULT_MINQUAL, DEFAULT_PROPORTION_READS, DEFAULT_QUALFILTER,
     DEFAULT_STRAND,
 };
+use crate::ValidMinKmer;
 
 /// Given a list of input files, parses them into triples of name, filename and
 /// [`None`] to be used with [SkaDict](`crate::ska_dict::SkaDict::new()`).
@@ -141,4 +143,77 @@ pub fn get_input_list(
 /// Checks if any input files are fastq
 pub fn any_fastq(files: &[InputFastx]) -> bool {
     files.iter().any(|file| file.2.is_some())
+}
+
+/// Counts number of fastq files
+pub fn count_fastq(files: &[InputFastx]) -> usize {
+    files.iter().filter(|file| file.2.is_some()).count()
+}
+
+/// Collects filepaths to the first 2 fastq files into a tuple
+pub fn get_2_fastq_path(files: &[InputFastx]) -> (String, String) {
+    let out: Vec<String> = files
+        .iter()
+        .filter(|file| file.2.is_some())
+        .take(2)
+        .map(|x| x.1.clone())
+        .collect();
+
+    if out.len().gt(&1) {
+        (out[0].clone(), out[1].clone())
+    } else {
+        panic!("Trying to get 2 fastq files from a vector with <2 elements");
+    }
+}
+
+/// Calculates minimum kmer cutoff depending on user provided argument
+pub fn kmer_min_cutoff(
+    v: &Option<ValidMinKmer>,
+    files: &[InputFastx],
+    rep_64: bool,
+    k: &usize,
+    rc: bool,
+    verbose: bool,
+) -> u16 {
+    // Minimum kmer cutoff logic
+    if v.is_none() {
+        log::info!(
+            "Using user-provided minimum kmer value of {}",
+            DEFAULT_MINCOUNT
+        );
+        DEFAULT_MINCOUNT
+    } else {
+        match v.unwrap() {
+            // User-provided value (already checked by cli parser)
+            ValidMinKmer::Val(x) => {
+                log::info!("Using user-provided minimum kmer value of {}", x);
+                x
+            }
+            // auto-calculate & there are enough fastq files
+            ValidMinKmer::Auto if count_fastq(files).ge(&2) => {
+                let (fastq_fwd, fastq_rev) = get_2_fastq_path(files);
+                let out: u16;
+                if rep_64 {
+                    let mut cov =
+                        CoverageHistogram::<u64>::new(&fastq_fwd, &fastq_rev, *k, rc, verbose);
+                    out = cov.fit_histogram().expect("Couldn't fit coverage model") as u16;
+                    cov.plot_hist();
+                } else {
+                    let mut cov =
+                        CoverageHistogram::<u128>::new(&fastq_fwd, &fastq_rev, *k, rc, verbose);
+                    out = cov.fit_histogram().expect("Couldn't fit coverage model") as u16;
+                    cov.plot_hist();
+                }
+                log::info!("Using inferred minimum kmer value of {}", out);
+                out
+            }
+            // Not enough fastq files, use default and warn user
+            ValidMinKmer::Auto => {
+                log::info!(
+                    "Not enough fastq files to fit mixture model, using default kmer count of 5"
+                );
+                DEFAULT_MINCOUNT
+            }
+        }
+    }
 }

--- a/src/io_utils.rs
+++ b/src/io_utils.rs
@@ -140,12 +140,5 @@ pub fn get_input_list(
 
 /// Checks if any input files are fastq
 pub fn any_fastq(files: &[InputFastx]) -> bool {
-    let mut fastq = false;
-    for file in files {
-        if file.2.is_some() {
-            fastq = true;
-            break;
-        }
-    }
-    fastq
+    files.iter().any(|file| file.2.is_some())
 }

--- a/src/io_utils.rs
+++ b/src/io_utils.rs
@@ -167,10 +167,9 @@ pub fn get_2_fastq_path(files: &[InputFastx]) -> (String, String) {
 }
 
 /// Calculates minimum kmer cutoff depending on user provided argument
-pub fn kmer_min_cutoff(
+pub fn kmer_min_cutoff<IntT: for<'a> UInt<'a>>(
     v: &Option<ValidMinKmer>,
     files: &[InputFastx],
-    rep_64: bool,
     k: &usize,
     rc: bool,
     verbose: bool,
@@ -192,18 +191,10 @@ pub fn kmer_min_cutoff(
             // auto-calculate & there are enough fastq files
             ValidMinKmer::Auto if count_fastq(files).ge(&2) => {
                 let (fastq_fwd, fastq_rev) = get_2_fastq_path(files);
-                let out: u16;
-                if rep_64 {
-                    let mut cov =
-                        CoverageHistogram::<u64>::new(&fastq_fwd, &fastq_rev, *k, rc, verbose);
-                    out = cov.fit_histogram().expect("Couldn't fit coverage model") as u16;
-                    cov.plot_hist();
-                } else {
-                    let mut cov =
-                        CoverageHistogram::<u128>::new(&fastq_fwd, &fastq_rev, *k, rc, verbose);
-                    out = cov.fit_histogram().expect("Couldn't fit coverage model") as u16;
-                    cov.plot_hist();
-                }
+                let mut cov =
+                    CoverageHistogram::<IntT>::new(&fastq_fwd, &fastq_rev, *k, rc, verbose);
+                let out = cov.fit_histogram().expect("Couldn't fit coverage model") as u16;
+                cov.plot_hist();
                 log::info!("Using inferred minimum kmer value of {}", out);
                 out
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,26 +504,16 @@ pub fn main() {
             // Read input
             let input_files = get_input_list(file_list, seq_files);
             let rc = !*single_strand;
-
-            // Are using 64 or 128 bit representation
-            let rep_64: bool = k.le(&31);
-            if rep_64 {
-                log::info!("k={}: using 64-bit representation", *k);
-            } else {
-                log::info!("k={}: using 128-bit representation", *k);
-            }
-
-            // Calculate minimum kmer cutoff
-            let cutoff = kmer_min_cutoff(min_count, &input_files, rep_64, k, rc, args.verbose);
-
-            let quality = QualOpts {
-                min_count: cutoff,
-                min_qual: *min_qual,
-                qual_filter: *qual_filter,
-            };
-
             // Build, merge
-            if rep_64 {
+            // check for 64 or 128 bit representation
+            if k.le(&31) {
+                log::info!("k={}: using 64-bit representation", *k);
+                let cutoff = kmer_min_cutoff::<u64>(min_count, &input_files, k, rc, args.verbose);
+                let quality = QualOpts {
+                    min_count: cutoff,
+                    min_qual: *min_qual,
+                    qual_filter: *qual_filter,
+                };
                 let merged_dict = build_and_merge::<u64>(
                     &input_files,
                     *k,
@@ -536,6 +526,13 @@ pub fn main() {
                 // Save
                 save_skf(&merged_dict, output);
             } else {
+                log::info!("k={}: using 128-bit representation", *k);
+                let cutoff = kmer_min_cutoff::<u128>(min_count, &input_files, k, rc, args.verbose);
+                let quality = QualOpts {
+                    min_count: cutoff,
+                    min_qual: *min_qual,
+                    qual_filter: *qual_filter,
+                };
                 let merged_dict = build_and_merge::<u128>(
                     &input_files,
                     *k,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,6 @@
 
 #![warn(missing_docs)]
 use std::fmt;
-use std::ops::Deref;
 use std::time::Instant;
 
 use clap::ValueEnum;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,14 +506,15 @@ pub fn main() {
             let rc = !*single_strand;
             // Build, merge
             // check for 64 or 128 bit representation
+            let mut quality = QualOpts {
+                min_count: 0,
+                min_qual: *min_qual,
+                qual_filter: *qual_filter,
+            };
             if k.le(&31) {
                 log::info!("k={}: using 64-bit representation", *k);
-                let cutoff = kmer_min_cutoff::<u64>(min_count, &input_files, k, rc, args.verbose);
-                let quality = QualOpts {
-                    min_count: cutoff,
-                    min_qual: *min_qual,
-                    qual_filter: *qual_filter,
-                };
+                quality.min_count =
+                    kmer_min_cutoff::<u64>(min_count, &input_files, k, rc, args.verbose);
                 let merged_dict = build_and_merge::<u64>(
                     &input_files,
                     *k,
@@ -527,12 +528,8 @@ pub fn main() {
                 save_skf(&merged_dict, output);
             } else {
                 log::info!("k={}: using 128-bit representation", *k);
-                let cutoff = kmer_min_cutoff::<u128>(min_count, &input_files, k, rc, args.verbose);
-                let quality = QualOpts {
-                    min_count: cutoff,
-                    min_qual: *min_qual,
-                    qual_filter: *qual_filter,
-                };
+                quality.min_count =
+                    kmer_min_cutoff::<u128>(min_count, &input_files, k, rc, args.verbose);
                 let merged_dict = build_and_merge::<u128>(
                     &input_files,
                     *k,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,11 +562,11 @@ pub fn main() {
                 // User has provided something other than auto, attempt to parse to u16
                 Some(s) => {
                     let k: u16 = s.parse().expect("Invalid minimum kmer count");
-                    if k.ge(&5) {
+                    if k.ge(&1) {
                         log::info!("Using provided minimum kmer value of {}", k);
                         k
                     } else {
-                        panic!("Minimum kmer count must be >= 5");
+                        panic!("Minimum kmer count must be >= 1");
                     }
                 }
                 // Value not provided, use default

--- a/src/merge_ska_array.rs
+++ b/src/merge_ska_array.rs
@@ -625,7 +625,7 @@ pub struct KmerIter<'a, IntT> {
     index: usize,
 }
 
-impl<'a, IntT> Iterator for KmerIter<'a, IntT>
+impl<IntT> Iterator for KmerIter<'_, IntT>
 where
     IntT: for<'b> UInt<'b>,
 {

--- a/src/ska_dict/bit_encoding.rs
+++ b/src/ska_dict/bit_encoding.rs
@@ -124,7 +124,7 @@ pub trait UInt<'a>:
     fn hash_val(self, hash_fn: &RandomState) -> u64;
 }
 
-impl<'a> UInt<'a> for u64 {
+impl UInt<'_> for u64 {
     #[inline(always)]
     fn rev_comp(mut self, k_size: usize) -> Self {
         // This part reverses the bases by shuffling them using an on/off pattern
@@ -182,7 +182,7 @@ impl<'a> UInt<'a> for u64 {
     }
 }
 
-impl<'a> UInt<'a> for u128 {
+impl UInt<'_> for u128 {
     #[inline(always)]
     fn rev_comp(mut self, k_size: usize) -> u128 {
         // This part reverses the bases by shuffling them using an on/off pattern

--- a/src/ska_ref.rs
+++ b/src/ska_ref.rs
@@ -99,7 +99,6 @@ where
     ambig_mask: bool,
 
     /// Input sequence
-
     /// Chromosome names
     chrom_names: Vec<String>,
     /// Sequence, indexed by chromosome, then position
@@ -108,7 +107,6 @@ where
     repeat_coors: Vec<usize>,
 
     /// Mapping information
-
     /// Positions of mapped bases as (chrom, pos)
     mapped_pos: Vec<(usize, usize)>,
     /// Array of mapped bases, rows loci, columns samples

--- a/src/ska_ref/idx_check.rs
+++ b/src/ska_ref/idx_check.rs
@@ -47,7 +47,7 @@ pub struct IdxCheckIter<'a> {
     idx: usize,
 }
 
-impl<'a> Iterator for IdxCheckIter<'a> {
+impl Iterator for IdxCheckIter<'_> {
     type Item = (usize, usize);
 
     fn next(&mut self) -> Option<(usize, usize)> {

--- a/tests/align.rs
+++ b/tests/align.rs
@@ -14,7 +14,7 @@ use pretty_assertions::assert_eq;
 fn build_cli() {
     let sandbox = TestSetup::setup();
     // Create an rfile in the tmp dir
-    let rfile_name = sandbox.create_rfile(&"test", FxType::Fasta);
+    let rfile_name = sandbox.create_rfile("test", FxType::Fasta);
 
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
@@ -23,7 +23,7 @@ fn build_cli() {
         .arg(rfile_name)
         .arg("-o")
         .arg("basic_build_opts")
-        .args(&["-v", "--threads", "2", "-k", "31"])
+        .args(["-v", "--threads", "2", "-k", "31"])
         .assert()
         .success();
 
@@ -68,7 +68,7 @@ fn align_cli() {
         .arg(sandbox.file_string("test_2.fa", TestDir::Input))
         .arg("-o")
         .arg("basic.aln")
-        .args(&[
+        .args([
             "-v",
             "--threads",
             "2",
@@ -359,7 +359,7 @@ fn parallel_align() {
         .arg(rfile_name)
         .arg("-o")
         .arg("serial_build")
-        .args(&["-v", "--threads", "1", "-k", "15"])
+        .args(["-v", "--threads", "1", "-k", "15"])
         .assert()
         .success();
 
@@ -379,7 +379,7 @@ fn parallel_align() {
         .arg(rfile_name)
         .arg("-o")
         .arg("parallel_build")
-        .args(&["-v", "--threads", "4", "-k", "15"])
+        .args(["-v", "--threads", "4", "-k", "15"])
         .assert()
         .success();
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,11 +13,11 @@ use hashbrown::HashSet;
 use pretty_assertions::assert_eq;
 
 // Creates correct path for input/output files
-static FILE_IN: &'static str = "tests/test_files_in";
-static FILE_TEST: &'static str = "tests/test_results_correct";
-static SYM_IN: &'static str = "input";
-static SYM_TEST: &'static str = "correct";
-static RFILE_NAME: &'static str = "file_list.txt";
+static FILE_IN: &str = "tests/test_files_in";
+static FILE_TEST: &str = "tests/test_results_correct";
+static SYM_IN: &str = "input";
+static SYM_TEST: &str = "correct";
+static RFILE_NAME: &str = "file_list.txt";
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum TestDir {
@@ -185,7 +185,7 @@ pub fn var_hash(aln_string: &[u8]) -> HashSet<Vec<char>> {
         variant_pairs.insert(var_vec);
     }
 
-    return variant_pairs;
+    variant_pairs
 }
 
 // Helper for comparing mapped alignments with different sample names

--- a/tests/distance.rs
+++ b/tests/distance.rs
@@ -16,7 +16,7 @@ fn basic_dists() {
         .arg("distance")
         .arg(sandbox.file_string("merge.skf", TestDir::Input))
         .arg("-v")
-        .args(&["--threads", "2"])
+        .args(["--threads", "2"])
         .assert()
         .stdout_eq_path(sandbox.file_string("merge.dist.stdout", TestDir::Correct));
 
@@ -24,7 +24,7 @@ fn basic_dists() {
         .current_dir(sandbox.get_wd())
         .arg("distance")
         .arg(sandbox.file_string("merge.skf", TestDir::Input))
-        .args(&["-o", "dists.txt"])
+        .args(["-o", "dists.txt"])
         .assert()
         .success();
     sandbox.file_check("dists.txt", "merge.dist.stdout");
@@ -35,7 +35,7 @@ fn basic_dists() {
         .arg("distance")
         .arg(sandbox.file_string("merge_k41.skf", TestDir::Input))
         .arg("-v")
-        .args(&["--threads", "2"])
+        .args(["--threads", "2"])
         .assert()
         .stdout_eq_path(sandbox.file_string("merge_k41.dist.stdout", TestDir::Correct));
 }
@@ -52,7 +52,7 @@ fn dist_filter() {
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
         .arg("--allow-ambiguous")
         .arg("-v")
-        .args(&["--threads", "2"])
+        .args(["--threads", "2"])
         .assert()
         .stdout_eq_path(sandbox.file_string("merge_k9.dist.stdout", TestDir::Correct));
 
@@ -70,7 +70,7 @@ fn dist_filter() {
         .current_dir(sandbox.get_wd())
         .arg("distance")
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
-        .args(&["--min-freq", "1"])
+        .args(["--min-freq", "1"])
         .arg("-v")
         .assert()
         .stdout_eq_path(sandbox.file_string("merge_k9_min_freq.dist.stdout", TestDir::Correct));
@@ -103,9 +103,9 @@ fn multisample_dists() {
         .arg("distance")
         .arg("multidist.skf")
         .arg("-v")
-        .args(&["--min-freq", "0"])
+        .args(["--min-freq", "0"])
         .arg("--allow-ambiguous")
-        .args(&["--threads", "2"])
+        .args(["--threads", "2"])
         .assert()
         .stdout_eq_path(sandbox.file_string("multidist.stdout", TestDir::Correct));
 

--- a/tests/fasta_input.rs
+++ b/tests/fasta_input.rs
@@ -185,7 +185,7 @@ fn repeats() {
         .arg("dup_ss.skf")
         .arg("--filter")
         .arg("no-const")
-        .args(&["--min-freq", "1"])
+        .args(["--min-freq", "1"])
         .assert()
         .success();
 
@@ -241,7 +241,7 @@ fn palindromes() {
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("otto.skf")
-        .args(&["--filter", "no-filter"])
+        .args(["--filter", "no-filter"])
         .assert()
         .stdout_eq_path(sandbox.file_string("palindrome.stdout", TestDir::Correct));
 
@@ -285,7 +285,7 @@ fn palindromes() {
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("ottootto.skf")
-        .args(&["--filter", "no-filter"])
+        .args(["--filter", "no-filter"])
         .assert()
         .stdout_eq_path(sandbox.file_string("palindrome_reps.stdout", TestDir::Correct));
 }

--- a/tests/fastq_input.rs
+++ b/tests/fastq_input.rs
@@ -508,3 +508,20 @@ fn cov_check() {
         .assert()
         .failure();
 }
+
+#[test]
+fn build_auto_check() {
+    let sandbox = TestSetup::setup();
+
+    let rfile_name = sandbox.create_rfile("test", FxType::Fastq);
+    Command::new(cargo_bin("ska"))
+        .current_dir(sandbox.get_wd())
+        .arg("build")
+        .arg("-f")
+        .arg(rfile_name)
+        .arg("-o")
+        .arg("reads")
+        .args(["--min-count", "auto", "-v", "-k", "9", "--min-qual", "2"])
+        .assert()
+        .success();
+}

--- a/tests/fastq_input.rs
+++ b/tests/fastq_input.rs
@@ -12,7 +12,7 @@ use crate::common::*;
 #[test]
 fn align_fastq() {
     let sandbox = TestSetup::setup();
-    let rfile_name = sandbox.create_rfile(&"test", FxType::Fastq);
+    let rfile_name = sandbox.create_rfile("test", FxType::Fastq);
 
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
@@ -21,7 +21,7 @@ fn align_fastq() {
         .arg(rfile_name)
         .arg("-o")
         .arg("reads")
-        .args(&["--min-count", "2", "-v", "-k", "9", "--min-qual", "2"])
+        .args(["--min-count", "2", "-v", "-k", "9", "--min-qual", "2"])
         .assert()
         .success();
 
@@ -36,13 +36,12 @@ fn align_fastq() {
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
-        .args(&["-k", "9"])
+        .args(["-k", "9"])
         .arg(sandbox.file_string("test_1.fa", TestDir::Input))
         .arg(sandbox.file_string("test_2.fa", TestDir::Input))
-        .args(&["-o", "fasta_k9"])
+        .args(["-o", "fasta_k9"])
         .output()
-        .unwrap()
-        .stdout;
+        .unwrap();
 
     let fasta_align_out = Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
@@ -60,7 +59,7 @@ fn align_fastq() {
 #[test]
 fn count_check() {
     let sandbox = TestSetup::setup();
-    let rfile_name = sandbox.create_rfile(&"test_count", FxType::Fastq);
+    let rfile_name = sandbox.create_rfile("test_count", FxType::Fastq);
 
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
@@ -69,7 +68,7 @@ fn count_check() {
         .arg(rfile_name)
         .arg("-o")
         .arg("reads_k7_c1")
-        .args(&["--min-count", "1", "-v", "-k", "7"])
+        .args(["--min-count", "1", "-v", "-k", "7"])
         .assert()
         .success();
 
@@ -93,7 +92,7 @@ fn count_check() {
         .arg(rfile_name)
         .arg("-o")
         .arg("reads_k7_c3")
-        .args(&["--min-count", "3", "-v", "-k", "7"])
+        .args(["--min-count", "3", "-v", "-k", "7"])
         .assert()
         .success();
 
@@ -114,7 +113,7 @@ fn count_check() {
 #[test]
 fn count_check_long() {
     let sandbox = TestSetup::setup();
-    let rfile_name = sandbox.create_rfile(&"test_long", FxType::Fastq);
+    let rfile_name = sandbox.create_rfile("test_long", FxType::Fastq);
 
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
@@ -123,7 +122,7 @@ fn count_check_long() {
         .arg(rfile_name)
         .arg("-o")
         .arg("reads_k63_c1")
-        .args(&["--min-count", "1", "-v", "-k", "63"])
+        .args(["--min-count", "1", "-v", "-k", "63"])
         .assert()
         .success();
 
@@ -148,7 +147,7 @@ fn count_check_long() {
         .arg(rfile_name)
         .arg("-o")
         .arg("reads_k63_c3")
-        .args(&["--min-count", "3", "-v", "-k", "63"])
+        .args(["--min-count", "3", "-v", "-k", "63"])
         .assert()
         .success();
 
@@ -173,7 +172,7 @@ fn count_check_long() {
         .arg("-o")
         .arg("reads_k63_c3_ss")
         .arg("--single-strand")
-        .args(&["--min-count", "2", "-v", "-k", "63"])
+        .args(["--min-count", "2", "-v", "-k", "63"])
         .assert()
         .success();
 
@@ -196,7 +195,7 @@ fn count_check_long() {
 #[test]
 fn map_fastq() {
     let sandbox = TestSetup::setup();
-    let rfile_name = sandbox.create_rfile(&"test", FxType::Fastq);
+    let rfile_name = sandbox.create_rfile("test", FxType::Fastq);
 
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
@@ -205,7 +204,7 @@ fn map_fastq() {
         .arg(rfile_name)
         .arg("-o")
         .arg("reads")
-        .args(&["--min-count", "1", "-v", "-k", "9", "--min-qual", "2"])
+        .args(["--min-count", "1", "-v", "-k", "9", "--min-qual", "2"])
         .assert()
         .success();
 
@@ -225,7 +224,7 @@ fn map_fastq() {
         .arg(sandbox.file_string("test_2.fa", TestDir::Input))
         .arg("-o")
         .arg("assemblies")
-        .args(&["-v", "-k", "9"])
+        .args(["-v", "-k", "9"])
         .assert()
         .success();
 
@@ -248,7 +247,7 @@ fn map_fastq() {
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
         .arg("reads.skf")
-        .args(&["-f", "vcf"])
+        .args(["-f", "vcf"])
         .output()
         .unwrap()
         .stdout;
@@ -258,7 +257,7 @@ fn map_fastq() {
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
         .arg("assemblies.skf")
-        .args(&["-f", "vcf"])
+        .args(["-f", "vcf"])
         .output()
         .unwrap()
         .stdout;
@@ -281,7 +280,7 @@ fn error_fastq() {
     let sandbox = TestSetup::setup();
 
     // Without errors
-    let rfile_name = sandbox.create_rfile(&"test", FxType::Fastq);
+    let rfile_name = sandbox.create_rfile("test", FxType::Fastq);
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
@@ -289,7 +288,7 @@ fn error_fastq() {
         .arg(rfile_name)
         .arg("-o")
         .arg("reads")
-        .args(&["--min-count", "3", "-v", "-k", "9", "--min-qual", "2"])
+        .args(["--min-count", "3", "-v", "-k", "9", "--min-qual", "2"])
         .assert()
         .success();
 
@@ -303,7 +302,7 @@ fn error_fastq() {
     let mut all_hash = var_hash(&fastq_align_out_all);
 
     // With no quality filtering
-    let rfile_name = sandbox.create_rfile(&"test_quality", FxType::Fastq);
+    let rfile_name = sandbox.create_rfile("test_quality", FxType::Fastq);
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
@@ -311,7 +310,7 @@ fn error_fastq() {
         .arg(rfile_name)
         .arg("-o")
         .arg("reads")
-        .args(&[
+        .args([
             "--min-count",
             "5",
             "-v",
@@ -334,7 +333,7 @@ fn error_fastq() {
     assert_eq!(var_hash(&fastq_align_out_quality_nofilter), all_hash);
 
     // With only quality filtering the middle base
-    let rfile_name = sandbox.create_rfile(&"test_quality_base", FxType::Fastq);
+    let rfile_name = sandbox.create_rfile("test_quality_base", FxType::Fastq);
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
@@ -342,7 +341,7 @@ fn error_fastq() {
         .arg(rfile_name)
         .arg("-o")
         .arg("reads")
-        .args(&[
+        .args([
             "--min-count",
             "5",
             "-v",
@@ -368,7 +367,7 @@ fn error_fastq() {
 
     // With errors
     all_hash.remove(&vec!['C', 'T']);
-    let rfile_name = sandbox.create_rfile(&"test_error", FxType::Fastq);
+    let rfile_name = sandbox.create_rfile("test_error", FxType::Fastq);
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
@@ -376,7 +375,7 @@ fn error_fastq() {
         .arg(rfile_name)
         .arg("-o")
         .arg("reads")
-        .args(&["--min-count", "5", "-v", "-k", "9", "--min-qual", "2"])
+        .args(["--min-count", "5", "-v", "-k", "9", "--min-qual", "2"])
         .assert()
         .success();
 
@@ -391,7 +390,7 @@ fn error_fastq() {
     assert_eq!(var_hash(&fastq_align_out_error), all_hash);
 
     // With low quality score
-    let rfile_name = sandbox.create_rfile(&"test_quality", FxType::Fastq);
+    let rfile_name = sandbox.create_rfile("test_quality", FxType::Fastq);
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
@@ -399,7 +398,7 @@ fn error_fastq() {
         .arg(rfile_name)
         .arg("-o")
         .arg("reads")
-        .args(&["--min-count", "5", "-v", "-k", "9", "--min-qual", "30"])
+        .args(["--min-count", "5", "-v", "-k", "9", "--min-qual", "30"])
         .assert()
         .success();
 
@@ -414,7 +413,7 @@ fn error_fastq() {
     assert_eq!(var_hash(&fastq_align_out_quality), all_hash);
 
     // With low quality score in flanking region
-    let rfile_name = sandbox.create_rfile(&"test_quality_base", FxType::Fastq);
+    let rfile_name = sandbox.create_rfile("test_quality_base", FxType::Fastq);
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
@@ -422,7 +421,7 @@ fn error_fastq() {
         .arg(rfile_name)
         .arg("-o")
         .arg("reads")
-        .args(&[
+        .args([
             "--min-count",
             "5",
             "-v",
@@ -447,7 +446,7 @@ fn error_fastq() {
     assert_eq!(var_hash(&fastq_align_out_quality), all_hash);
 
     // With low quality score in middle base region
-    let rfile_name = sandbox.create_rfile(&"test_quality_base", FxType::Fastq);
+    let rfile_name = sandbox.create_rfile("test_quality_base", FxType::Fastq);
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
@@ -455,7 +454,7 @@ fn error_fastq() {
         .arg(rfile_name)
         .arg("-o")
         .arg("reads")
-        .args(&["--min-count", "5", "-v", "-k", "9"])
+        .args(["--min-count", "5", "-v", "-k", "9"])
         .assert()
         .success();
 

--- a/tests/fastq_input.rs
+++ b/tests/fastq_input.rs
@@ -524,4 +524,15 @@ fn build_auto_check() {
         .args(["--min-count", "auto", "-v", "-k", "9", "--min-qual", "2"])
         .assert()
         .success();
+
+    Command::new(cargo_bin("ska"))
+        .current_dir(sandbox.get_wd())
+        .arg("build")
+        .arg("-f")
+        .arg(rfile_name)
+        .arg("-o")
+        .arg("reads")
+        .args(["--min-count", "-1", "-v", "-k", "9", "--min-qual", "2"])
+        .assert()
+        .failure();
 }

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -30,7 +30,7 @@ fn map_aln() {
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
         .arg(sandbox.file_string("merge.skf", TestDir::Input))
-        .args(&["-v", "--threads", "2"])
+        .args(["-v", "--threads", "2"])
         .assert()
         .stdout_eq_path(sandbox.file_string("map_aln.stdout", TestDir::Correct));
 
@@ -100,7 +100,7 @@ fn map_u128() {
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
         .arg(sandbox.file_string("merge_k41.skf", TestDir::Input))
-        .args(&["-v", "--threads", "2"])
+        .args(["-v", "--threads", "2"])
         .assert()
         .stdout_eq_path(sandbox.file_string("map_aln_k41.stdout", TestDir::Correct));
 
@@ -109,7 +109,7 @@ fn map_u128() {
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
         .arg(sandbox.file_string("merge_k41.skf", TestDir::Input))
-        .args(&["-v", "--threads", "2"])
+        .args(["-v", "--threads", "2"])
         .arg("-f")
         .arg("vcf")
         .assert()
@@ -257,7 +257,7 @@ fn repeat_mask() {
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
         .arg("-v")
         .arg("--repeat-mask")
-        .args(&["--format", "vcf"])
+        .args(["--format", "vcf"])
         .assert()
         .stdout_matches_path(sandbox.file_string("map_vcf_k9.masked.stdout", TestDir::Correct));
 
@@ -289,7 +289,7 @@ fn repeat_mask() {
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
         .arg("-v")
         .arg("--repeat-mask")
-        .args(&["--format", "vcf"])
+        .args(["--format", "vcf"])
         .assert()
         .stdout_matches_path(
             sandbox.file_string("map_vcf_two_chrom.masked.stdout", TestDir::Correct),

--- a/tests/skf_ops.rs
+++ b/tests/skf_ops.rs
@@ -53,7 +53,7 @@ fn merge_delete() {
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
         .arg("delete")
-        .args(&["-s", "merge.skf"])
+        .args(["-s", "merge.skf"])
         .arg("test_3")
         .assert()
         .failure();
@@ -69,7 +69,7 @@ fn merge_delete() {
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
         .arg("delete")
-        .args(&["-s", "merge.skf"])
+        .args(["-s", "merge.skf"])
         .arg("test_2")
         .assert()
         .success();
@@ -125,8 +125,11 @@ fn merge_delete_u128() {
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
         .arg("delete")
-        .args(&["-s", "merge.skf"])
-        .args(&["-f", &sandbox.file_string("missing_delete.txt", TestDir::Input)])
+        .args(["-s", "merge.skf"])
+        .args([
+            "-f",
+            &sandbox.file_string("missing_delete.txt", TestDir::Input),
+        ])
         .arg("-v")
         .assert()
         .failure();
@@ -142,8 +145,8 @@ fn merge_delete_u128() {
     Command::new(cargo_bin("ska"))
         .current_dir(sandbox.get_wd())
         .arg("delete")
-        .args(&["-s", "merge.skf"])
-        .args(&["-o", "merge_delete"])
+        .args(["-s", "merge.skf"])
+        .args(["-o", "merge_delete"])
         .arg("test_2")
         .arg("-v")
         .assert()
@@ -191,7 +194,7 @@ fn weed() {
         .arg("merge.skf")
         .arg("--filter")
         .arg("no-const")
-        .args(&["--min-freq", "1"])
+        .args(["--min-freq", "1"])
         .assert()
         .success();
 
@@ -271,7 +274,7 @@ fn weed() {
         .arg("build_k41.skf")
         .arg("--filter")
         .arg("no-ambig-or-const")
-        .args(&["--min-freq", "1"])
+        .args(["--min-freq", "1"])
         .arg("-v")
         .assert()
         .success();


### PR DESCRIPTION
For the `build` command the user can now specify `--min-count auto` and the mixture model from the `cov` command will be fit to the first two fastq files provided by the user. This calculates a minimum kmer cutoff which is subsequently used in the `build` command.

- The input for `min-count` is now a struct that can handle a mix of `auto` and `u16` values. There is a parser in `cli.rs` called `valid_min_kmer` that goes from the user provided string to the required struct (`ValidMinKmer`, defined in `cli.rs`).
- Added some utility functions that count the number of fastq files in a list of files and select the first 2 of those files in `io_utils.rs`. Also wrote an iterator version of the function `any_fastq`.
- Fixed some clippy warning elided lifetimes and other warnings.
- If the user provides a value for `min-count` it is used unless it is <1. If they specify `auto` an attempt is made to fit the mixture model. If this works the inferred value is used. If there are less than 2 fastq files passed by the user the default value of 5 is used. If no value is provided for `min-count` the default value of 5 is used. All activity regarding the value used is reported to the user via `log::info!`.