### PR TITLE
fix: Removed deprecated cargo_bin() function in snapbox

### DIFF
--- a/tests/align.rs
+++ b/tests/align.rs
@@ -1,4 +1,4 @@
-use snapbox::cmd::{cargo_bin, Command};
+use snapbox::cmd::{self, Command};
 
 pub mod common;
 use crate::common::*;
@@ -16,7 +16,7 @@ fn build_cli() {
     // Create an rfile in the tmp dir
     let rfile_name = sandbox.create_rfile("test", FxType::Fasta);
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -34,7 +34,7 @@ fn build_cli() {
 fn build_proportion_reads() {
     let sandbox = TestSetup::setup();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-k")
@@ -49,7 +49,7 @@ fn build_proportion_reads() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("nk")
         .arg("build_proportion_reads.skf")
@@ -63,7 +63,7 @@ fn build_proportion_reads() {
 fn align_cli() {
     let sandbox = TestSetup::setup();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg(sandbox.file_string("test_1.fa", TestDir::Input))
@@ -89,7 +89,7 @@ fn align_cli() {
 fn build_and_align() {
     let sandbox = TestSetup::setup();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-o")
@@ -101,7 +101,7 @@ fn build_and_align() {
         .assert()
         .success();
 
-    let fasta_align_out = Command::new(cargo_bin("ska"))
+    let fasta_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("basic_build.skf")
@@ -118,7 +118,7 @@ fn build_and_align() {
 fn long_kmers() {
     let sandbox = TestSetup::setup();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-o")
@@ -131,7 +131,7 @@ fn long_kmers() {
         .assert()
         .success();
 
-    let fasta_align_out_k33 = Command::new(cargo_bin("ska"))
+    let fasta_align_out_k33 = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("build_k33.skf")
@@ -144,7 +144,7 @@ fn long_kmers() {
     assert_eq!(var_hash(&fasta_align_out_k33), correct_aln);
 
     // Check 128 bits used
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("nk")
         .arg("build_k33.skf")
@@ -152,7 +152,7 @@ fn long_kmers() {
         .assert()
         .stdout_matches_path(sandbox.file_string("k33.stdout", TestDir::Correct));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-o")
@@ -170,7 +170,7 @@ fn long_kmers() {
 fn basic_align() {
     let sandbox = TestSetup::setup();
 
-    let fasta_align_out = Command::new(cargo_bin("ska"))
+    let fasta_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg(sandbox.file_string("test_1.fa", TestDir::Input))
@@ -188,7 +188,7 @@ fn filters() {
     let sandbox = TestSetup::setup();
 
     // With k=9 there is a repeated k-mer
-    let unfilt_align_out = Command::new(cargo_bin("ska"))
+    let unfilt_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
@@ -206,7 +206,7 @@ fn filters() {
         assert_eq!(full_length, length);
     }
 
-    let noambig_align_out = Command::new(cargo_bin("ska"))
+    let noambig_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
@@ -223,7 +223,7 @@ fn filters() {
         assert_eq!(full_length - 1, length);
     }
 
-    let const_filt_align_out = Command::new(cargo_bin("ska"))
+    let const_filt_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
@@ -237,7 +237,7 @@ fn filters() {
     let correct_aln = HashSet::from([vec!['T', 'A'], vec!['C', 'T'], vec!['S', 'G']]);
     assert_eq!(var_hash(&const_filt_align_out), correct_aln);
 
-    let no_ambig_or_const_align_out = Command::new(cargo_bin("ska"))
+    let no_ambig_or_const_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
@@ -251,7 +251,7 @@ fn filters() {
     let correct_aln = HashSet::from([vec!['T', 'A'], vec!['C', 'T']]);
     assert_eq!(var_hash(&no_ambig_or_const_align_out), correct_aln);
 
-    let ambig_filter_align_out = Command::new(cargo_bin("ska"))
+    let ambig_filter_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
@@ -267,7 +267,7 @@ fn filters() {
     assert_eq!(var_hash(&ambig_filter_align_out), correct_aln);
 
     // Output everything by using min-freq 0, check for behaviour on gap only sites
-    let unfilt_align_out = Command::new(cargo_bin("ska"))
+    let unfilt_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
@@ -286,7 +286,7 @@ fn filters() {
         assert_eq!(full_length, length);
     }
 
-    let filt_align_out = Command::new(cargo_bin("ska"))
+    let filt_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
@@ -306,7 +306,7 @@ fn filters() {
         assert_eq!(full_length, length);
     }
 
-    let unfilt_align_out = Command::new(cargo_bin("ska"))
+    let unfilt_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
@@ -325,7 +325,7 @@ fn filters() {
         assert_eq!(full_length, length);
     }
 
-    let filt_align_out = Command::new(cargo_bin("ska"))
+    let filt_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
@@ -354,7 +354,7 @@ fn parallel_align() {
     let rfile_name = sandbox.create_par_rfile();
 
     // Serial alignment
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -365,7 +365,7 @@ fn parallel_align() {
         .assert()
         .success();
 
-    let serial_align_out = Command::new(cargo_bin("ska"))
+    let serial_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("serial_build.skf")
@@ -374,7 +374,7 @@ fn parallel_align() {
         .stdout;
 
     // Parallel alignment algorithm used
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -385,7 +385,7 @@ fn parallel_align() {
         .assert()
         .success();
 
-    let parallel_align_out = Command::new(cargo_bin("ska"))
+    let parallel_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("parallel_build.skf")

--- a/tests/distance.rs
+++ b/tests/distance.rs
@@ -1,4 +1,4 @@
-use snapbox::cmd::{cargo_bin, Command};
+use snapbox::cmd::{self, Command};
 
 pub mod common;
 use crate::common::*;
@@ -11,7 +11,7 @@ fn basic_dists() {
     let sandbox = TestSetup::setup();
 
     // Two differences, so dist 2.0
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("distance")
         .arg(sandbox.file_string("merge.skf", TestDir::Input))
@@ -20,7 +20,7 @@ fn basic_dists() {
         .assert()
         .stdout_eq_path(sandbox.file_string("merge.dist.stdout", TestDir::Correct));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("distance")
         .arg(sandbox.file_string("merge.skf", TestDir::Input))
@@ -30,7 +30,7 @@ fn basic_dists() {
     sandbox.file_check("dists.txt", "merge.dist.stdout");
 
     // One difference
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("distance")
         .arg(sandbox.file_string("merge_k41.skf", TestDir::Input))
@@ -46,7 +46,7 @@ fn dist_filter() {
     let sandbox = TestSetup::setup();
 
     // Has an S,G site, giving 0.5
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("distance")
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
@@ -57,7 +57,7 @@ fn dist_filter() {
         .stdout_eq_path(sandbox.file_string("merge_k9.dist.stdout", TestDir::Correct));
 
     // Ignoring the S,G gives 2.0
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("distance")
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
@@ -66,7 +66,7 @@ fn dist_filter() {
         .stdout_eq_path(sandbox.file_string("merge_k9_no_ambig.dist.stdout", TestDir::Correct));
 
     // Making only k-mers in both reduces mismatches to zero
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("distance")
         .arg(sandbox.file_string("merge_k9.skf", TestDir::Input))
@@ -81,7 +81,7 @@ fn multisample_dists() {
     let sandbox = TestSetup::setup();
 
     // NB: Ensure dists of sample pair are the same as the above test
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg(sandbox.file_string("N_test_1.fa", TestDir::Input))
@@ -98,7 +98,7 @@ fn multisample_dists() {
         .success();
 
     // Test with defaults (and that output order correct irrespective of threads)
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("distance")
         .arg("multidist.skf")
@@ -108,7 +108,7 @@ fn multisample_dists() {
         .stdout_eq_path(sandbox.file_string("multidist.stdout", TestDir::Correct));
 
     // Test with min freq -- this removes all k-mers here
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("distance")
         .arg("multidist.skf")
@@ -118,7 +118,7 @@ fn multisample_dists() {
         .stdout_eq_path(sandbox.file_string("multidist.minfreq.stdout", TestDir::Correct));
 
     // Test with ambig bases
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("distance")
         .arg("multidist.skf")

--- a/tests/fasta_input.rs
+++ b/tests/fasta_input.rs
@@ -1,4 +1,4 @@
-use snapbox::cmd::{cargo_bin, Command};
+use snapbox::cmd::{self, Command};
 
 use hashbrown::HashSet;
 
@@ -13,7 +13,7 @@ fn align_n() {
     let sandbox = TestSetup::setup();
 
     // Tests that N and n are skipped, so second variant doesn't appear in align
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg(sandbox.file_string("N_test_1.fa", TestDir::Input))
@@ -23,7 +23,7 @@ fn align_n() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("N_test.skf")
@@ -36,7 +36,7 @@ fn map_n() {
     let sandbox = TestSetup::setup();
 
     // Tests that N and n are skipped, so second variant doesn't appear in map
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg(sandbox.file_string("N_test_1.fa", TestDir::Input))
@@ -48,7 +48,7 @@ fn map_n() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -62,7 +62,7 @@ fn rev_comp() {
     let sandbox = TestSetup::setup();
 
     // Test an RC sequence gives same alignment out
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-o")
@@ -74,7 +74,7 @@ fn rev_comp() {
         .assert()
         .success();
 
-    let no_rc_aln = Command::new(cargo_bin("ska"))
+    let no_rc_aln = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("fwd_build.skf")
@@ -82,7 +82,7 @@ fn rev_comp() {
         .unwrap()
         .stdout;
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-o")
@@ -94,7 +94,7 @@ fn rev_comp() {
         .assert()
         .success();
 
-    let rc_aln = Command::new(cargo_bin("ska"))
+    let rc_aln = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("fwd_build.skf")
@@ -105,7 +105,7 @@ fn rev_comp() {
     assert_eq!(var_hash(&no_rc_aln), var_hash(&rc_aln));
 
     // Now with rc off
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-o")
@@ -118,7 +118,7 @@ fn rev_comp() {
         .assert()
         .success();
 
-    let ss_aln = Command::new(cargo_bin("ska"))
+    let ss_aln = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("fwd_build.skf")
@@ -128,7 +128,7 @@ fn rev_comp() {
 
     assert_eq!(var_hash(&ss_aln).is_empty(), true);
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-o")
@@ -141,7 +141,7 @@ fn rev_comp() {
         .assert()
         .success();
 
-    let fasta_align_out_k33 = Command::new(cargo_bin("ska"))
+    let fasta_align_out_k33 = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("build_k33.skf")
@@ -158,7 +158,7 @@ fn repeats() {
     let sandbox = TestSetup::setup();
 
     // Tests that three repeats are correctly shown with IUPAC codes
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-k")
@@ -171,7 +171,7 @@ fn repeats() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("dup_ss.skf")
@@ -179,7 +179,7 @@ fn repeats() {
         .stdout_eq_path(sandbox.file_string("dup_ss.stdout", TestDir::Correct));
 
     // Also tests this is just a single variant
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("weed")
         .arg("dup_ss.skf")
@@ -189,7 +189,7 @@ fn repeats() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("nk")
         .arg("dup_ss.skf")
@@ -199,7 +199,7 @@ fn repeats() {
 
     // Tests that the RC of these IUPAC codes is correct
     // (the rc of the input k-mer is the canonical one)
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-k")
@@ -211,7 +211,7 @@ fn repeats() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("dup_rc.skf")
@@ -224,7 +224,7 @@ fn palindromes() {
     let sandbox = TestSetup::setup();
 
     // Check that palindrome k-mers (self-rc) are correctly ambiguous
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-k")
@@ -237,7 +237,7 @@ fn palindromes() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("otto.skf")
@@ -246,7 +246,7 @@ fn palindromes() {
         .stdout_eq_path(sandbox.file_string("palindrome.stdout", TestDir::Correct));
 
     // Single strand forces orientation so no ambiguity
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-k")
@@ -259,7 +259,7 @@ fn palindromes() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("otan.skf")
@@ -268,7 +268,7 @@ fn palindromes() {
 
     // Check that palindrome k-mers (self-rc) are correctly ambiguous, and
     // work correctly when multiple copies are present
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-k")
@@ -281,7 +281,7 @@ fn palindromes() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("ottootto.skf")

--- a/tests/fastq_input.rs
+++ b/tests/fastq_input.rs
@@ -1,4 +1,4 @@
-use snapbox::cmd::{cargo_bin, Command};
+use snapbox::cmd::{self, Command};
 
 use hashbrown::HashSet;
 
@@ -14,7 +14,7 @@ fn align_fastq() {
     let sandbox = TestSetup::setup();
     let rfile_name = sandbox.create_rfile("test", FxType::Fastq);
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -25,7 +25,7 @@ fn align_fastq() {
         .assert()
         .success();
 
-    let fastq_align_out = Command::new(cargo_bin("ska"))
+    let fastq_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("reads.skf")
@@ -33,7 +33,7 @@ fn align_fastq() {
         .unwrap()
         .stdout;
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .args(["-k", "9"])
@@ -43,7 +43,7 @@ fn align_fastq() {
         .output()
         .unwrap();
 
-    let fasta_align_out = Command::new(cargo_bin("ska"))
+    let fasta_align_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("fasta_k9.skf")
@@ -61,7 +61,7 @@ fn count_check() {
     let sandbox = TestSetup::setup();
     let rfile_name = sandbox.create_rfile("test_count", FxType::Fastq);
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -72,7 +72,7 @@ fn count_check() {
         .assert()
         .success();
 
-    let fastq_align_c1_out = Command::new(cargo_bin("ska"))
+    let fastq_align_c1_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("reads_k7_c1.skf")
@@ -85,7 +85,7 @@ fn count_check() {
 
     // In sample two there are three split k-mers supporting T, one supporting A
     // So above see a W, here the A gets filtered and we just see a T
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -96,7 +96,7 @@ fn count_check() {
         .assert()
         .success();
 
-    let fastq_align_c3_out = Command::new(cargo_bin("ska"))
+    let fastq_align_c3_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("reads_k7_c3.skf")
@@ -115,7 +115,7 @@ fn count_check_long() {
     let sandbox = TestSetup::setup();
     let rfile_name = sandbox.create_rfile("test_long", FxType::Fastq);
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -126,7 +126,7 @@ fn count_check_long() {
         .assert()
         .success();
 
-    let fastq_align_c1_out = Command::new(cargo_bin("ska"))
+    let fastq_align_c1_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("reads_k63_c1.skf")
@@ -140,7 +140,7 @@ fn count_check_long() {
 
     // In sample two there are three split k-mers supporting T, one supporting A
     // So above see a W, here the A gets filtered and we just see a T
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -151,7 +151,7 @@ fn count_check_long() {
         .assert()
         .success();
 
-    let fastq_align_c3_out = Command::new(cargo_bin("ska"))
+    let fastq_align_c3_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("reads_k63_c3.skf")
@@ -164,7 +164,7 @@ fn count_check_long() {
     assert_eq!(var_hash(&fastq_align_c3_out), correct_aln);
 
     // Now ignoring the rc
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -176,7 +176,7 @@ fn count_check_long() {
         .assert()
         .success();
 
-    let fastq_align_c3_out_ss = Command::new(cargo_bin("ska"))
+    let fastq_align_c3_out_ss = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("reads_k63_c3_ss.skf")
@@ -197,7 +197,7 @@ fn map_fastq() {
     let sandbox = TestSetup::setup();
     let rfile_name = sandbox.create_rfile("test", FxType::Fastq);
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -208,7 +208,7 @@ fn map_fastq() {
         .assert()
         .success();
 
-    let fastq_map_out = Command::new(cargo_bin("ska"))
+    let fastq_map_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -217,7 +217,7 @@ fn map_fastq() {
         .unwrap()
         .stdout;
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg(sandbox.file_string("test_1.fa", TestDir::Input))
@@ -228,7 +228,7 @@ fn map_fastq() {
         .assert()
         .success();
 
-    let fasta_map_out = Command::new(cargo_bin("ska"))
+    let fasta_map_out = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -242,7 +242,7 @@ fn map_fastq() {
         String::from_utf8(fasta_map_out).unwrap()
     );
 
-    let fastq_map_out_vcf = Command::new(cargo_bin("ska"))
+    let fastq_map_out_vcf = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -252,7 +252,7 @@ fn map_fastq() {
         .unwrap()
         .stdout;
 
-    let fasta_map_out_vcf = Command::new(cargo_bin("ska"))
+    let fasta_map_out_vcf = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -281,7 +281,7 @@ fn error_fastq() {
 
     // Without errors
     let rfile_name = sandbox.create_rfile("test", FxType::Fastq);
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -292,7 +292,7 @@ fn error_fastq() {
         .assert()
         .success();
 
-    let fastq_align_out_all = Command::new(cargo_bin("ska"))
+    let fastq_align_out_all = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("reads.skf")
@@ -303,7 +303,7 @@ fn error_fastq() {
 
     // With no quality filtering
     let rfile_name = sandbox.create_rfile("test_quality", FxType::Fastq);
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -322,7 +322,7 @@ fn error_fastq() {
         .assert()
         .success();
 
-    let fastq_align_out_quality_nofilter = Command::new(cargo_bin("ska"))
+    let fastq_align_out_quality_nofilter = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("reads.skf")
@@ -334,7 +334,7 @@ fn error_fastq() {
 
     // With only quality filtering the middle base
     let rfile_name = sandbox.create_rfile("test_quality_base", FxType::Fastq);
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -355,7 +355,7 @@ fn error_fastq() {
         .assert()
         .success();
 
-    let fastq_align_out_quality_base = Command::new(cargo_bin("ska"))
+    let fastq_align_out_quality_base = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("reads.skf")
@@ -368,7 +368,7 @@ fn error_fastq() {
     // With errors
     all_hash.remove(&vec!['C', 'T']);
     let rfile_name = sandbox.create_rfile("test_error", FxType::Fastq);
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -379,7 +379,7 @@ fn error_fastq() {
         .assert()
         .success();
 
-    let fastq_align_out_error = Command::new(cargo_bin("ska"))
+    let fastq_align_out_error = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("reads.skf")
@@ -391,7 +391,7 @@ fn error_fastq() {
 
     // With low quality score
     let rfile_name = sandbox.create_rfile("test_quality", FxType::Fastq);
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -402,7 +402,7 @@ fn error_fastq() {
         .assert()
         .success();
 
-    let fastq_align_out_quality = Command::new(cargo_bin("ska"))
+    let fastq_align_out_quality = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("reads.skf")
@@ -414,7 +414,7 @@ fn error_fastq() {
 
     // With low quality score in flanking region
     let rfile_name = sandbox.create_rfile("test_quality_base", FxType::Fastq);
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -435,7 +435,7 @@ fn error_fastq() {
         .assert()
         .success();
 
-    let fastq_align_out_quality = Command::new(cargo_bin("ska"))
+    let fastq_align_out_quality = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("reads.skf")
@@ -447,7 +447,7 @@ fn error_fastq() {
 
     // With low quality score in middle base region
     let rfile_name = sandbox.create_rfile("test_quality_base", FxType::Fastq);
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -458,7 +458,7 @@ fn error_fastq() {
         .assert()
         .success();
 
-    let fastq_align_out_quality = Command::new(cargo_bin("ska"))
+    let fastq_align_out_quality = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("reads.skf")
@@ -474,7 +474,7 @@ fn error_fastq() {
 fn cov_check() {
     let sandbox = TestSetup::setup();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("cov")
         .arg(sandbox.file_string("test_1_fwd.fastq.gz", TestDir::Input))
@@ -485,7 +485,7 @@ fn cov_check() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("cov")
         .arg(sandbox.file_string("test_long_1_fwd.fastq.gz", TestDir::Input))
@@ -497,7 +497,7 @@ fn cov_check() {
         .success();
 
     // Doesn't run with fasta
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("cov")
         .arg(sandbox.file_string("test_1.fa", TestDir::Input))
@@ -514,7 +514,7 @@ fn build_auto_check() {
     let sandbox = TestSetup::setup();
 
     let rfile_name = sandbox.create_rfile("test", FxType::Fastq);
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")
@@ -525,7 +525,7 @@ fn build_auto_check() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-f")

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -1,4 +1,4 @@
-use snapbox::cmd::{cargo_bin, Command};
+use snapbox::cmd::{self, Command};
 
 #[cfg(test)]
 use pretty_assertions::assert_eq;
@@ -12,7 +12,7 @@ use crate::common::*;
 fn map_aln() {
     let sandbox = TestSetup::setup();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -25,7 +25,7 @@ fn map_aln() {
 
     assert_eq!(true, sandbox.file_exists("map.aln"));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -34,7 +34,7 @@ fn map_aln() {
         .assert()
         .stdout_eq_path(sandbox.file_string("map_aln.stdout", TestDir::Correct));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -42,7 +42,7 @@ fn map_aln() {
         .assert()
         .stdout_eq_path(sandbox.file_string("map_aln_k9.stdout", TestDir::Correct));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -52,7 +52,7 @@ fn map_aln() {
         .assert()
         .stdout_eq_path(sandbox.file_string("map_aln_k9_filter.stdout", TestDir::Correct));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref_two_chrom.fa", TestDir::Input))
@@ -60,7 +60,7 @@ fn map_aln() {
         .assert()
         .stdout_eq_path(sandbox.file_string("map_aln_two_chrom.stdout", TestDir::Correct));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -69,7 +69,7 @@ fn map_aln() {
         .assert()
         .stdout_eq_path(sandbox.file_string("map_aln_indels.stdout", TestDir::Correct));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-k")
@@ -82,7 +82,7 @@ fn map_aln() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("ambig_test_ref.fa", TestDir::Input))
@@ -95,7 +95,7 @@ fn map_aln() {
 fn map_u128() {
     let sandbox = TestSetup::setup();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -104,7 +104,7 @@ fn map_u128() {
         .assert()
         .stdout_eq_path(sandbox.file_string("map_aln_k41.stdout", TestDir::Correct));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -120,7 +120,7 @@ fn map_u128() {
 fn map_vcf() {
     let sandbox = TestSetup::setup();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -135,7 +135,7 @@ fn map_vcf() {
 
     assert_eq!(true, sandbox.file_exists("map.vcf"));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -145,7 +145,7 @@ fn map_vcf() {
         .assert()
         .stdout_matches_path(sandbox.file_string("map_vcf.stdout", TestDir::Correct));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref_two_chrom.fa", TestDir::Input))
@@ -155,7 +155,7 @@ fn map_vcf() {
         .assert()
         .stdout_matches_path(sandbox.file_string("map_vcf_two_chrom.stdout", TestDir::Correct));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -171,7 +171,7 @@ fn map_vcf() {
 fn map_rev_comp() {
     let sandbox = TestSetup::setup();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-o")
@@ -183,7 +183,7 @@ fn map_rev_comp() {
         .assert()
         .success();
 
-    let rc_map = Command::new(cargo_bin("ska"))
+    let rc_map = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -192,7 +192,7 @@ fn map_rev_comp() {
         .unwrap()
         .stdout;
 
-    let fwd_map = Command::new(cargo_bin("ska"))
+    let fwd_map = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -203,7 +203,7 @@ fn map_rev_comp() {
 
     cmp_map_aln(&rc_map, &fwd_map);
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-o")
@@ -216,7 +216,7 @@ fn map_rev_comp() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -224,7 +224,7 @@ fn map_rev_comp() {
         .assert()
         .stdout_eq_path(sandbox.file_string("map_ss.stdout", TestDir::Correct));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -240,7 +240,7 @@ fn map_rev_comp() {
 fn repeat_mask() {
     let sandbox = TestSetup::setup();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -250,7 +250,7 @@ fn repeat_mask() {
         .assert()
         .stdout_eq_path(sandbox.file_string("map_aln_k9.masked.stdout", TestDir::Correct));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref.fa", TestDir::Input))
@@ -262,7 +262,7 @@ fn repeat_mask() {
         .stdout_matches_path(sandbox.file_string("map_vcf_k9.masked.stdout", TestDir::Correct));
 
     // Two identical chromosomes. All bases masked
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref_two_chrom.fa", TestDir::Input))
@@ -272,7 +272,7 @@ fn repeat_mask() {
         .assert()
         .stdout_eq_path(sandbox.file_string("map_all_repeats.masked.stdout", TestDir::Correct));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref_two_chrom_repeats.fa", TestDir::Input))
@@ -282,7 +282,7 @@ fn repeat_mask() {
         .assert()
         .stdout_eq_path(sandbox.file_string("map_aln_two_chrom.masked.stdout", TestDir::Correct));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("map")
         .arg(sandbox.file_string("test_ref_two_chrom_repeats.fa", TestDir::Input))

--- a/tests/skalo.rs
+++ b/tests/skalo.rs
@@ -1,4 +1,4 @@
-use snapbox::cmd::{cargo_bin, Command};
+use snapbox::cmd::{self, Command};
 
 #[cfg(test)]
 pub mod common;
@@ -11,7 +11,7 @@ use crate::common::*;
 fn ska_lo() {
     let sandbox = TestSetup::setup();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("lo")
         .arg("-r")
@@ -23,7 +23,7 @@ fn ska_lo() {
 
     sandbox.file_check("test_skalo_snps.fas", "test_skalo_snps.fas");
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("lo")
         .arg(sandbox.file_string("test_skalo_indel.skf", TestDir::Input))

--- a/tests/skf_ops.rs
+++ b/tests/skf_ops.rs
@@ -1,4 +1,4 @@
-use snapbox::cmd::{cargo_bin, Command};
+use snapbox::cmd::{self, Command};
 
 #[cfg(test)]
 use pretty_assertions::assert_eq;
@@ -12,7 +12,7 @@ use crate::common::{TestDir, TestSetup};
 fn merge_delete() {
     let sandbox = TestSetup::setup();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg(sandbox.file_string("test_1.fa", TestDir::Input))
@@ -21,7 +21,7 @@ fn merge_delete() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg(sandbox.file_string("test_2.fa", TestDir::Input))
@@ -30,7 +30,7 @@ fn merge_delete() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("merge")
         .arg("test_1.skf")
@@ -42,7 +42,7 @@ fn merge_delete() {
 
     assert_eq!(true, sandbox.file_exists("merge.skf"));
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("nk")
         .arg("merge.skf")
@@ -50,7 +50,7 @@ fn merge_delete() {
         .stdout_matches_path(sandbox.file_string("merge_nk.stdout", TestDir::Correct));
 
     // Try removing non-existent sample
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("delete")
         .args(["-s", "merge.skf"])
@@ -59,14 +59,14 @@ fn merge_delete() {
         .failure();
 
     // delete a sample then check nk same as original
-    let test1_nk = Command::new(cargo_bin("ska"))
+    let test1_nk = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("nk")
         .arg("test_1.skf")
         .output()
         .unwrap();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("delete")
         .args(["-s", "merge.skf"])
@@ -74,7 +74,7 @@ fn merge_delete() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("nk")
         .arg("merge.skf")
@@ -86,7 +86,7 @@ fn merge_delete() {
 fn merge_delete_u128() {
     let sandbox = TestSetup::setup();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg(sandbox.file_string("test_1.fa", TestDir::Input))
@@ -97,7 +97,7 @@ fn merge_delete_u128() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg(sandbox.file_string("test_2.fa", TestDir::Input))
@@ -108,7 +108,7 @@ fn merge_delete_u128() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("merge")
         .arg("test_1.skf")
@@ -122,7 +122,7 @@ fn merge_delete_u128() {
     assert_eq!(true, sandbox.file_exists("merge.skf"));
 
     // Try removing non-existent sample
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("delete")
         .args(["-s", "merge.skf"])
@@ -135,14 +135,14 @@ fn merge_delete_u128() {
         .failure();
 
     // delete a sample then check nk same as original
-    let test1_nk = Command::new(cargo_bin("ska"))
+    let test1_nk = Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("nk")
         .arg("test_1.skf")
         .output()
         .unwrap();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("delete")
         .args(["-s", "merge.skf"])
@@ -152,7 +152,7 @@ fn merge_delete_u128() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("nk")
         .arg("merge_delete.skf")
@@ -171,7 +171,7 @@ fn weed() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("weed")
         .arg("merge.skf")
@@ -180,7 +180,7 @@ fn weed() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("merge.skf")
@@ -188,7 +188,7 @@ fn weed() {
         .stdout_eq_path(sandbox.file_string("weed_align.stdout", TestDir::Correct));
 
     // With const sites/filter and nk full info
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("weed")
         .arg("merge.skf")
@@ -198,7 +198,7 @@ fn weed() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("nk")
         .arg("merge.skf")
@@ -214,7 +214,7 @@ fn weed() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("weed")
         .arg("merge_k9.skf")
@@ -222,7 +222,7 @@ fn weed() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("nk")
         .arg("merge_k9.skf")
@@ -237,7 +237,7 @@ fn weed() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("weed")
         .arg("merge.skf")
@@ -247,7 +247,7 @@ fn weed() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("align")
         .arg("merge.skf")
@@ -255,7 +255,7 @@ fn weed() {
         .stdout_eq_path(sandbox.file_string("weed_align_reverse.stdout", TestDir::Correct));
 
     // With longer k-mers
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("build")
         .arg("-o")
@@ -268,7 +268,7 @@ fn weed() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("weed")
         .arg("build_k41.skf")
@@ -279,7 +279,7 @@ fn weed() {
         .assert()
         .success();
 
-    Command::new(cargo_bin("ska"))
+    Command::new(cmd::cargo_bin!("ska"))
         .current_dir(sandbox.get_wd())
         .arg("nk")
         .arg("build_k41.skf")


### PR DESCRIPTION
See the deprecation notice in the [snapbox docs](https://docs.rs/snapbox/latest/snapbox/cmd/fn.cargo_bin.html).

fixes #103 