### PR TITLE
I105 dist stats

### DIFF
--- a/src/generic_modes.rs
+++ b/src/generic_modes.rs
@@ -172,19 +172,18 @@ pub fn distance<IntT: for<'a> UInt<'a>>(
 
     // Write out the distances (long form)
     let mut f = set_ostream(output_prefix);
-    writeln!(&mut f, "Sample1\tSample2\tDistance\tMismatches").unwrap();
+    writeln!(
+        &mut f,
+        "Sample1\tSample2\tDistance\tMismatches (proportion)\tMatch count\tMismatch count"
+    )
+    .unwrap();
     let sample_names = ska_array.names();
     for (idx, (dist_vec, sample1)) in distances.iter().zip(sample_names).enumerate() {
         for (dist, j) in dist_vec.iter().zip(std::ops::Range {
             start: (idx + 1),
             end: sample_names.len(),
         }) {
-            writeln!(
-                &mut f,
-                "{sample1}\t{}\t{dist}",
-                sample_names[j]
-            )
-            .unwrap();
+            writeln!(&mut f, "{sample1}\t{}\t{dist}", sample_names[j]).unwrap();
         }
     }
 }

--- a/src/merge_ska_array.rs
+++ b/src/merge_ska_array.rs
@@ -43,19 +43,16 @@ pub struct VariantDist {
     /// Absolute count of matching sites
     match_count: usize,
     /// Absolute count of mismatching sites
-    mismatch_count: usize
+    mismatch_count: usize,
 }
 
 /// Prints distance, mismatch proportion, count matching, count mismatching (tab separated)
 impl fmt::Display for VariantDist {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
-                f,
-                "{:.2}\t{:.5}\t{}\t{}",
-                self.distance,
-                self.mismatch_prop,
-                self.match_count,
-                self.mismatch_count
+            f,
+            "{:.2}\t{:.5}\t{}\t{}",
+            self.distance, self.mismatch_prop, self.match_count, self.mismatch_count,
         )
     }
 }
@@ -583,7 +580,12 @@ where
         } else {
             mismatches / (matches + mismatches)
         };
-        VariantDist {distance, mismatch_prop, match_count: matches as usize, mismatch_count: mismatches as usize}
+        VariantDist {
+            distance,
+            mismatch_prop,
+            match_count: matches as usize,
+            mismatch_count: mismatches as usize,
+        }
     }
 
     /// Iterator over split k-mers and middle bases

--- a/tests/test_results_correct/merge.dist.stdout
+++ b/tests/test_results_correct/merge.dist.stdout
@@ -1,2 +1,2 @@
-Sample1	Sample2	Distance	Mismatches
-test_1	test_2	2.00	0.82051
+Sample1	Sample2	Distance	Mismatches (proportion)	Match count	Mismatch count
+test_1	test_2	2.00	0.82051	14	64

--- a/tests/test_results_correct/merge_k41.dist.stdout
+++ b/tests/test_results_correct/merge_k41.dist.stdout
@@ -1,2 +1,2 @@
-Sample1	Sample2	Distance	Mismatches
-test_1	test_2	1.00	0.97674
+Sample1	Sample2	Distance	Mismatches (proportion)	Match count	Mismatch count
+test_1	test_2	1.00	0.97674	1	42

--- a/tests/test_results_correct/merge_k9.dist.stdout
+++ b/tests/test_results_correct/merge_k9.dist.stdout
@@ -1,2 +1,2 @@
-Sample1	Sample2	Distance	Mismatches
-test_1	test_2	2.50	0.45455
+Sample1	Sample2	Distance	Mismatches (proportion)	Match count	Mismatch count
+test_1	test_2	2.50	0.45455	36	30

--- a/tests/test_results_correct/merge_k9_min_freq.dist.stdout
+++ b/tests/test_results_correct/merge_k9_min_freq.dist.stdout
@@ -1,2 +1,2 @@
-Sample1	Sample2	Distance	Mismatches
-test_1	test_2	2.00	0.00000
+Sample1	Sample2	Distance	Mismatches (proportion)	Match count	Mismatch count
+test_1	test_2	2.00	0.00000	37	0

--- a/tests/test_results_correct/merge_k9_no_ambig.dist.stdout
+++ b/tests/test_results_correct/merge_k9_no_ambig.dist.stdout
@@ -1,2 +1,2 @@
-Sample1	Sample2	Distance	Mismatches
-test_1	test_2	2.00	0.44776
+Sample1	Sample2	Distance	Mismatches (proportion)	Match count	Mismatch count
+test_1	test_2	2.00	0.44776	37	30

--- a/tests/test_results_correct/multidist.ambig.stdout
+++ b/tests/test_results_correct/multidist.ambig.stdout
@@ -1,16 +1,16 @@
-Sample1	Sample2	Distance	Mismatches
-N_test_1	N_test_2	2.00	0.53571
-N_test_1	ambig_test_1	0.00	1.00000
-N_test_1	ambig_test_2	0.00	1.00000
-N_test_1	test_1	0.50	0.25455
-N_test_1	test_2	1.00	0.43333
-N_test_2	ambig_test_1	0.00	1.00000
-N_test_2	ambig_test_2	0.00	1.00000
-N_test_2	test_1	1.50	0.57576
-N_test_2	test_2	1.00	0.29091
-ambig_test_1	ambig_test_2	0.50	0.44444
-ambig_test_1	test_1	0.00	1.00000
-ambig_test_1	test_2	0.00	1.00000
-ambig_test_2	test_1	0.00	1.00000
-ambig_test_2	test_2	0.00	1.00000
-test_1	test_2	2.50	0.45455
+Sample1	Sample2	Distance	Mismatches (proportion)	Match count	Mismatch count
+N_test_1	N_test_2	2.00	0.53571	26	30
+N_test_1	ambig_test_1	0.00	1.00000	0	53
+N_test_1	ambig_test_2	0.00	1.00000	0	61
+N_test_1	test_1	0.50	0.25455	41	14
+N_test_1	test_2	1.00	0.43333	34	26
+N_test_2	ambig_test_1	0.00	1.00000	0	53
+N_test_2	ambig_test_2	0.00	1.00000	0	61
+N_test_2	test_1	1.50	0.57576	28	38
+N_test_2	test_2	1.00	0.29091	39	16
+ambig_test_1	ambig_test_2	0.50	0.44444	10	8
+ambig_test_1	test_1	0.00	1.00000	0	63
+ambig_test_1	test_2	0.00	1.00000	0	63
+ambig_test_2	test_1	0.00	1.00000	0	71
+ambig_test_2	test_2	0.00	1.00000	0	71
+test_1	test_2	2.50	0.45455	36	30

--- a/tests/test_results_correct/multidist.minfreq.stdout
+++ b/tests/test_results_correct/multidist.minfreq.stdout
@@ -1,16 +1,16 @@
-Sample1	Sample2	Distance	Mismatches
-N_test_1	N_test_2	0.00	0.00000
-N_test_1	ambig_test_1	0.00	0.00000
-N_test_1	ambig_test_2	0.00	0.00000
-N_test_1	test_1	0.00	0.00000
-N_test_1	test_2	0.00	0.00000
-N_test_2	ambig_test_1	0.00	0.00000
-N_test_2	ambig_test_2	0.00	0.00000
-N_test_2	test_1	0.00	0.00000
-N_test_2	test_2	0.00	0.00000
-ambig_test_1	ambig_test_2	0.00	0.00000
-ambig_test_1	test_1	0.00	0.00000
-ambig_test_1	test_2	0.00	0.00000
-ambig_test_2	test_1	0.00	0.00000
-ambig_test_2	test_2	0.00	0.00000
-test_1	test_2	0.00	0.00000
+Sample1	Sample2	Distance	Mismatches (proportion)	Match count	Mismatch count
+N_test_1	N_test_2	0.00	0.00000	0	0
+N_test_1	ambig_test_1	0.00	0.00000	0	0
+N_test_1	ambig_test_2	0.00	0.00000	0	0
+N_test_1	test_1	0.00	0.00000	0	0
+N_test_1	test_2	0.00	0.00000	0	0
+N_test_2	ambig_test_1	0.00	0.00000	0	0
+N_test_2	ambig_test_2	0.00	0.00000	0	0
+N_test_2	test_1	0.00	0.00000	0	0
+N_test_2	test_2	0.00	0.00000	0	0
+ambig_test_1	ambig_test_2	0.00	0.00000	0	0
+ambig_test_1	test_1	0.00	0.00000	0	0
+ambig_test_1	test_2	0.00	0.00000	0	0
+ambig_test_2	test_1	0.00	0.00000	0	0
+ambig_test_2	test_2	0.00	0.00000	0	0
+test_1	test_2	0.00	0.00000	0	0

--- a/tests/test_results_correct/multidist.stdout
+++ b/tests/test_results_correct/multidist.stdout
@@ -1,16 +1,16 @@
-Sample1	Sample2	Distance	Mismatches
-N_test_1	N_test_2	2.00	0.51724
-N_test_1	ambig_test_1	0.00	1.00000
-N_test_1	ambig_test_2	0.00	1.00000
-N_test_1	test_1	0.00	0.25926
-N_test_1	test_2	1.00	0.42623
-N_test_2	ambig_test_1	0.00	1.00000
-N_test_2	ambig_test_2	0.00	1.00000
-N_test_2	test_1	1.00	0.57576
-N_test_2	test_2	1.00	0.28571
-ambig_test_1	ambig_test_2	0.00	0.47059
-ambig_test_1	test_1	0.00	1.00000
-ambig_test_1	test_2	0.00	1.00000
-ambig_test_2	test_1	0.00	1.00000
-ambig_test_2	test_2	0.00	1.00000
-test_1	test_2	2.00	0.44776
+Sample1	Sample2	Distance	Mismatches (proportion)	Match count	Mismatch count
+N_test_1	N_test_2	2.00	0.51724	28	30
+N_test_1	ambig_test_1	0.00	1.00000	0	53
+N_test_1	ambig_test_2	0.00	1.00000	0	61
+N_test_1	test_1	0.00	0.25926	40	14
+N_test_1	test_2	1.00	0.42623	35	26
+N_test_2	ambig_test_1	0.00	1.00000	0	53
+N_test_2	ambig_test_2	0.00	1.00000	0	61
+N_test_2	test_1	1.00	0.57576	28	38
+N_test_2	test_2	1.00	0.28571	40	16
+ambig_test_1	ambig_test_2	0.00	0.47059	9	8
+ambig_test_1	test_1	0.00	1.00000	0	63
+ambig_test_1	test_2	0.00	1.00000	0	63
+ambig_test_2	test_1	0.00	1.00000	0	71
+ambig_test_2	test_2	0.00	1.00000	0	71
+test_1	test_2	2.00	0.44776	37	30


### PR DESCRIPTION
Added counts of matches and mismatches to the distance output.

I also looked at total, but including missing in both I think is unhelpful (tells you more about the whole .skf alignment than the pair of samples).

@kristyhoran @tseemann could you try this branch and confirm it's what you need?
(after checking out just run `cargo install --path .`, or if you don't want to overwrite your existing install run `cargo build --release`, then you can run from `target/release/ska`)

Closes #105 